### PR TITLE
`ControlledPQC` cuquantum support

### DIFF
--- a/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
@@ -128,6 +128,7 @@ class ControlledPQC(tf.keras.layers.Layer):
                  *,
                  repetitions=None,
                  backend='noiseless',
+                 use_cuquantum=False,
                  differentiator=None,
                  **kwargs):
         """Instantiate this layer.
@@ -153,6 +154,8 @@ class ControlledPQC(tf.keras.layers.Layer):
             `sampled_based` is True or it must inherit
             `cirq.sim.simulator.SimulatesExpectationValues` if `sample_based` is
             False.
+        use_cuquantum: Optional Python `bool` indicating whether or not to use 
+            GPU ops
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.
         """
@@ -235,10 +238,12 @@ class ControlledPQC(tf.keras.layers.Layer):
 
         if self._analytic:
             self._layer = expectation.Expectation(backend=backend,
-                                                  differentiator=differentiator)
+                                                  differentiator=differentiator,
+                                                  use_cuquantum=use_cuquantum)
         else:
             self._layer = sampled_expectation.SampledExpectation(
-                backend=backend, differentiator=differentiator)
+                backend=backend, differentiator=differentiator,
+                use_cuquantum=use_cuquantum)
 
         self._append_layer = elementary.AddCircuit()
 


### PR DESCRIPTION
Added CuQuantum support for `ControlledPQC` layer built upon cuQuantum `simulate_expectation` and `simulate_sampled_expectation` kernels. 