### PR TITLE
Upgrade cirq from 0.13.1 to ~= 1.0 and etc.

### DIFF
--- a/docs/tutorials/hello_many_worlds.ipynb
+++ b/docs/tutorials/hello_many_worlds.ipynb
@@ -255,7 +255,7 @@
         "# Create a circuit on these qubits using the parameters you created above.\n",
         "circuit = cirq.Circuit(\n",
         "    cirq.rx(a).on(q0),\n",
-        "    cirq.ry(b).on(q1), cirq.CNOT(control=q0, target=q1))\n",
+        "    cirq.ry(b).on(q1), cirq.CNOT(q0, q1))\n",
         "\n",
         "SVGCircuit(circuit)"
       ]

--- a/release/setup.py
+++ b/release/setup.py
@@ -51,7 +51,7 @@ class InstallPlatlib(install):
 
 
 REQUIRED_PACKAGES = [
-    'cirq-core==0.13.1', 'cirq-google==0.13.1', 'sympy == 1.8',
+    'cirq-core~=1.0', 'cirq-google~=1.0', 'sympy == 1.8',
     'googleapis-common-protos==1.52.0', 'google-api-core==1.21.0',
     'google-auth==1.18.0', 'protobuf==3.19.5'
 ]
@@ -59,7 +59,7 @@ REQUIRED_PACKAGES = [
 # placed as extra to not have required overwrite existing nightly installs if
 # they exist.
 EXTRA_PACKAGES = ['tensorflow == 2.11.0']
-CUR_VERSION = '0.7.3'
+CUR_VERSION = '0.7.4'
 
 
 class BinaryDistribution(Distribution):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cirq-core==0.13.1
-cirq-google==0.13.1
+cirq-core~=1.0
+cirq-google~=1.0
 sympy==1.8
 numpy==1.24.2  # TensorFlow can detect if it was built against other versions.
 nbformat==4.4.0

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -14,7 +14,17 @@
 # limitations under the License.
 # ==============================================================================
 echo "Testing All Bazel py_test and cc_tests.";
-test_outputs=$(bazel test -c opt --experimental_repo_remote_exec --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" --cxxopt="-std=c++17" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --notest_keep_going --test_output=errors //tensorflow_quantum/...)
+ENABLE_CUDA=${1}
+
+if [[ ${ENABLE_CUDA} == "gpu" ]]; then
+  echo "GPU mode. CUDA config is set."
+  CUDA_CONFIG="--config=cuda"
+else
+  echo "CPU mode."
+  CUDA_CONFIG=""
+fi
+
+test_outputs=$(bazel test -c opt ${CUDA_CONFIG} --experimental_repo_remote_exec --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" --cxxopt="-std=c++17" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --test_output=errors //tensorflow_quantum/...)
 exit_code=$?
 if [ "$exit_code" == "0" ]; then
 	echo "Testing Complete!";

--- a/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
@@ -204,8 +204,7 @@ class OpGetterInputChecks(tf.test.TestCase):
                                     expected_regex="Cirq.SimulatesFinalState"):
             mock_processor = mock.create_autospec(AbstractProcessor)
             circuit_execution_ops.get_state_op(
-                backend=cirq_google.ProcessorSampler(
-                    processor=mock_processor))
+                backend=cirq_google.ProcessorSampler(processor=mock_processor))
 
         with self.assertRaisesRegex(TypeError,
                                     expected_regex="must be type bool."):

--- a/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
@@ -27,6 +27,7 @@ from absl.testing import parameterized
 from scipy import stats
 import cirq
 import cirq_google
+from cirq_google.engine.abstract_processor import AbstractProcessor
 
 from tensorflow_quantum.core.ops import batch_util, circuit_execution_ops
 from tensorflow_quantum.python import util
@@ -115,11 +116,9 @@ class OpGetterInputChecks(tf.test.TestCase):
         circuit_execution_ops.get_expectation_op()
         with self.assertRaisesRegex(NotImplementedError,
                                     expected_regex='Sample-based'):
-            mock_engine = mock.Mock()
+            mock_processor = mock.create_autospec(AbstractProcessor)
             circuit_execution_ops.get_expectation_op(
-                cirq_google.QuantumEngineSampler(engine=mock_engine,
-                                                 processor_id='test',
-                                                 gate_set=cirq_google.XMON))
+                cirq_google.ProcessorSampler(processor=mock_processor))
         with self.assertRaisesRegex(
                 TypeError,
                 expected_regex="cirq.sim.simulator.SimulatesExpectationValues"):
@@ -145,11 +144,9 @@ class OpGetterInputChecks(tf.test.TestCase):
             backend=cirq.Simulator())
         circuit_execution_ops.get_sampled_expectation_op(
             backend=cirq.DensityMatrixSimulator())
-        mock_engine = mock.Mock()
+        mock_processor = mock.create_autospec(AbstractProcessor)
         circuit_execution_ops.get_sampled_expectation_op(
-            cirq_google.QuantumEngineSampler(engine=mock_engine,
-                                             processor_id='test',
-                                             gate_set=cirq_google.XMON))
+            cirq_google.ProcessorSampler(processor=mock_processor))
         with self.assertRaisesRegex(TypeError, expected_regex="a Cirq.Sampler"):
             circuit_execution_ops.get_sampled_expectation_op(backend="junk")
 
@@ -174,11 +171,9 @@ class OpGetterInputChecks(tf.test.TestCase):
         circuit_execution_ops.get_sampling_op(backend=cirq.Simulator())
         circuit_execution_ops.get_sampling_op(
             backend=cirq.DensityMatrixSimulator())
-        mock_engine = mock.Mock()
+        mock_processor = mock.create_autospec(AbstractProcessor)
         circuit_execution_ops.get_sampling_op(
-            backend=cirq_google.QuantumEngineSampler(engine=mock_engine,
-                                                     processor_id='test',
-                                                     gate_set=cirq_google.XMON))
+            backend=cirq_google.ProcessorSampler(processor=mock_processor))
         with self.assertRaisesRegex(TypeError,
                                     expected_regex="Expected a Cirq.Sampler"):
             circuit_execution_ops.get_sampling_op(backend="junk")
@@ -207,12 +202,10 @@ class OpGetterInputChecks(tf.test.TestCase):
             circuit_execution_ops.get_state_op(backend="junk")
         with self.assertRaisesRegex(TypeError,
                                     expected_regex="Cirq.SimulatesFinalState"):
-            mock_engine = mock.Mock()
+            mock_processor = mock.create_autospec(AbstractProcessor)
             circuit_execution_ops.get_state_op(
-                backend=cirq_google.QuantumEngineSampler(
-                    engine=mock_engine,
-                    processor_id='test',
-                    gate_set=cirq_google.XMON))
+                backend=cirq_google.ProcessorSampler(
+                    processor=mock_processor))
 
         with self.assertRaisesRegex(TypeError,
                                     expected_regex="must be type bool."):
@@ -339,7 +332,7 @@ class ExecutionOpsConsistentyTest(tf.test.TestCase, parameterized.TestCase):
         symbol_names = []
         circuit_batch, resolver_batch = \
             util.random_circuit_resolver_batch(
-                cirq.GridQubit.rect(4, 4), 5)
+                cirq.GridQubit.rect(3, 3), 5)
 
         symbol_values_array = np.array(
             [[resolver[symbol]
@@ -351,10 +344,6 @@ class ExecutionOpsConsistentyTest(tf.test.TestCase, parameterized.TestCase):
 
         cirq_states = batch_util.batch_calculate_state(circuit_batch,
                                                        resolver_batch, sim)
-        # Due to numpy memory allocation error with large circuits,
-        # we deallocate these variables.
-        del circuit_batch
-        del resolver_batch
 
         self.assertAllClose(cirq_states, op_states, atol=1e-5, rtol=1e-5)
 

--- a/tensorflow_quantum/core/ops/cirq_ops.py
+++ b/tensorflow_quantum/core/ops/cirq_ops.py
@@ -491,7 +491,7 @@ def _get_cirq_samples(sampler=cirq.Simulator()):
         ]
         max_n_qubits = max(len(p.all_qubits()) for p in programs)
 
-        if isinstance(sampler, cirq_google.QuantumEngineSampler):
+        if isinstance(sampler, cirq_google.ProcessorSampler):
             # group samples from identical circuits to reduce communication
             # overhead. Have to keep track of the order in which things came
             # in to make sure the output is ordered correctly

--- a/tensorflow_quantum/core/ops/cirq_ops_test.py
+++ b/tensorflow_quantum/core/ops/cirq_ops_test.py
@@ -26,6 +26,7 @@ import tensorflow as tf
 from absl.testing import parameterized
 import cirq
 import cirq_google
+from cirq_google.engine.abstract_processor import AbstractProcessor
 
 from tensorflow_quantum.core.ops import cirq_ops
 from tensorflow_quantum.core.serialize import serializer
@@ -348,11 +349,9 @@ class CirqSamplesTest(tf.test.TestCase, parameterized.TestCase):
         cirq_ops._get_cirq_samples()
         cirq_ops._get_cirq_samples(cirq.Simulator())
         cirq_ops._get_cirq_samples(cirq.DensityMatrixSimulator())
-        mock_engine = mock.Mock()
+        mock_processor = mock.create_autospec(AbstractProcessor)
         cirq_ops._get_cirq_samples(
-            cirq_google.QuantumEngineSampler(engine=mock_engine,
-                                             processor_id='test',
-                                             gate_set=cirq_google.XMON))
+            cirq_google.ProcessorSampler(processor=mock_processor))
 
     def test_cirq_sampling_op_inputs(self):
         """test input checking in the cirq sampling op."""
@@ -451,7 +450,9 @@ class CirqSamplesTest(tf.test.TestCase, parameterized.TestCase):
             def run_sweep(self, program, params, repetitions):
                 """Returns all ones in the correct sample shape."""
                 return [
-                    cirq.Result(
+                    cirq_google.EngineResult(
+                        job_id="1",
+                        job_finished_time="1",
                         params=param,
                         measurements={
                             'tfq':

--- a/tensorflow_quantum/core/ops/math_ops/tfq_inner_product.cc
+++ b/tensorflow_quantum/core/ops/math_ops/tfq_inner_product.cc
@@ -174,7 +174,7 @@ class TfqInnerProductOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as necessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
       if (nq > largest_nq) {
         // need to switch to larger statespace.
@@ -186,10 +186,10 @@ class TfqInnerProductOp : public tensorflow::OpKernel {
       //  the state if there is a possibility that circuit[i] and
       //  circuit[i + 1] produce the same state.
       ss.SetStateZero(sv);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
       }
-      for (int j = 0; j < other_fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < other_fused_circuits[i].size(); j++) {
         // (#679) Just ignore empty program
         if (fused_circuits[i].size() == 0) {
           (*output_tensor)(i, j) = std::complex<float>(1, 0);
@@ -197,7 +197,7 @@ class TfqInnerProductOp : public tensorflow::OpKernel {
         }
 
         ss.SetStateZero(scratch);
-        for (int k = 0; k < other_fused_circuits[i][j].size(); k++) {
+        for (size_t k = 0; k < other_fused_circuits[i][j].size(); k++) {
           qsim::ApplyFusedGate(sim, other_fused_circuits[i][j][k], scratch);
         }
 
@@ -255,13 +255,13 @@ class TfqInnerProductOp : public tensorflow::OpKernel {
           // no need to update scratch_state since ComputeExpectation
           // will take care of things for us.
           ss.SetStateZero(sv);
-          for (int j = 0; j < fused_circuits[cur_batch_index].size(); j++) {
+          for (size_t j = 0; j < fused_circuits[cur_batch_index].size(); j++) {
             qsim::ApplyFusedGate(sim, fused_circuits[cur_batch_index][j], sv);
           }
         }
 
         ss.SetStateZero(scratch);
-        for (int k = 0;
+        for (size_t k = 0;
              k <
              other_fused_circuits[cur_batch_index][cur_internal_index].size();
              k++) {

--- a/tensorflow_quantum/core/ops/math_ops/tfq_inner_product_grad.cc
+++ b/tensorflow_quantum/core/ops/math_ops/tfq_inner_product_grad.cc
@@ -398,13 +398,13 @@ class TfqInnerProductGradOp : public tensorflow::OpKernel {
           // if applicable compute control qubit mask and control value bits.
           uint64_t mask = 0;
           uint64_t cbits = 0;
-          for (int k = 0; k < cur_gate.controlled_by.size(); k++) {
+          for (size_t k = 0; k < cur_gate.controlled_by.size(); k++) {
             uint64_t control_loc = cur_gate.controlled_by[k];
             mask |= uint64_t{1} << control_loc;
             cbits |= ((cur_gate.cmask >> k) & 1) << control_loc;
           }
 
-          for (int k = 0;
+          for (size_t k = 0;
                k < gradient_gates[cur_batch_index][l - 1].grad_gates.size();
                k++) {
             // Copy sv_adj onto scratch2 in anticipation of non-unitary

--- a/tensorflow_quantum/core/ops/noise/tfq_noisy_expectation.cc
+++ b/tensorflow_quantum/core/ops/noise/tfq_noisy_expectation.cc
@@ -175,8 +175,8 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
 
     tensorflow::GuardedPhiloxRandom random_gen;
     int max_n_shots = 1;
-    for (int i = 0; i < num_samples.size(); i++) {
-      for (int j = 0; j < num_samples[i].size(); j++) {
+    for (size_t i = 0; i < num_samples.size(); i++) {
+      for (size_t j = 0; j < num_samples[i].size(); j++) {
         max_n_shots = std::max(max_n_shots, num_samples[i][j]);
       }
     }
@@ -188,12 +188,12 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as necessary.
-    for (int i = 0; i < ncircuits.size(); i++) {
+    for (size_t i = 0; i < ncircuits.size(); i++) {
       int nq = num_qubits[i];
 
       // (#679) Just ignore empty program
       if (ncircuits[i].channels.size() == 0) {
-        for (int j = 0; j < pauli_sums[i].size(); j++) {
+        for (size_t j = 0; j < pauli_sums[i].size(); j++) {
           (*output_tensor)(i, j) = -2.0;
         }
         continue;
@@ -220,7 +220,7 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
                              sv, unused_stats);
 
         // Use this trajectory as a source for all expectation calculations.
-        for (int j = 0; j < pauli_sums[i].size(); j++) {
+        for (size_t j = 0; j < pauli_sums[i].size(); j++) {
           if (run_samples[j] >= num_samples[i][j]) {
             continue;
           }
@@ -232,14 +232,14 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
           run_samples[j]++;
         }
         bool break_loop = true;
-        for (int j = 0; j < num_samples[i].size(); j++) {
+        for (size_t j = 0; j < num_samples[i].size(); j++) {
           if (run_samples[j] < num_samples[i][j]) {
             break_loop = false;
             break;
           }
         }
         if (break_loop) {
-          for (int j = 0; j < num_samples[i].size(); j++) {
+          for (size_t j = 0; j < num_samples[i].size(); j++) {
             rolling_sums[j] /= num_samples[i][j];
             (*output_tensor)(i, j) = static_cast<float>(rolling_sums[j]);
           }
@@ -280,8 +280,8 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
 
     tensorflow::GuardedPhiloxRandom random_gen;
     int max_n_shots = 1;
-    for (int i = 0; i < num_samples.size(); i++) {
-      for (int j = 0; j < num_samples[i].size(); j++) {
+    for (size_t i = 0; i < num_samples.size(); i++) {
+      for (size_t j = 0; j < num_samples[i].size(); j++) {
         max_n_shots = std::max(max_n_shots, num_samples[i][j]);
       }
     }
@@ -304,13 +304,13 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
           random_gen.ReserveSamples128(ncircuits.size() * max_n_shots + 1);
       tensorflow::random::SimplePhilox rand_source(&local_gen);
 
-      for (int i = 0; i < ncircuits.size(); i++) {
+      for (size_t i = 0; i < ncircuits.size(); i++) {
         int nq = num_qubits[i];
         int rep_offset = rep_offsets[start][i];
 
         // (#679) Just ignore empty program
         if (ncircuits[i].channels.size() == 0) {
-          for (int j = 0; j < pauli_sums[i].size(); j++) {
+          for (size_t j = 0; j < pauli_sums[i].size(); j++) {
             (*output_tensor)(i, j) = -2.0;
           }
           continue;
@@ -337,7 +337,7 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
                                sim, sv, unused_stats);
 
           // Compute expectations across all ops using this trajectory.
-          for (int j = 0; j < pauli_sums[i].size(); j++) {
+          for (size_t j = 0; j < pauli_sums[i].size(); j++) {
             int p_reps = (num_samples[i][j] + num_threads - 1) / num_threads;
             if (run_samples[j] >= p_reps + rep_offset) {
               continue;
@@ -354,7 +354,7 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
 
           // Check if we have run enough trajectories for all ops.
           bool break_loop = true;
-          for (int j = 0; j < num_samples[i].size(); j++) {
+          for (size_t j = 0; j < num_samples[i].size(); j++) {
             int p_reps = (num_samples[i][j] + num_threads - 1) / num_threads;
             if (run_samples[j] < p_reps + rep_offset) {
               break_loop = false;
@@ -364,7 +364,7 @@ class TfqNoisyExpectationOp : public tensorflow::OpKernel {
           if (break_loop) {
             // Lock writing to this batch index in output_tensor.
             batch_locks[i].lock();
-            for (int j = 0; j < num_samples[i].size(); j++) {
+            for (size_t j = 0; j < num_samples[i].size(); j++) {
               rolling_sums[j] /= num_samples[i][j];
               (*output_tensor)(i, j) += static_cast<float>(rolling_sums[j]);
             }

--- a/tensorflow_quantum/core/ops/noise/tfq_noisy_sampled_expectation.cc
+++ b/tensorflow_quantum/core/ops/noise/tfq_noisy_sampled_expectation.cc
@@ -177,8 +177,8 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
     tensorflow::GuardedPhiloxRandom random_gen;
     int max_psum_length = 1;
     int max_n_shots = 1;
-    for (int i = 0; i < pauli_sums.size(); i++) {
-      for (int j = 0; j < pauli_sums[i].size(); j++) {
+    for (size_t i = 0; i < pauli_sums.size(); i++) {
+      for (size_t j = 0; j < pauli_sums[i].size(); j++) {
         max_psum_length =
             std::max(max_psum_length, pauli_sums[i][j].terms().size());
         max_n_shots = std::max(max_n_shots, num_samples[i][j]);
@@ -192,12 +192,12 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as necessary.
-    for (int i = 0; i < ncircuits.size(); i++) {
+    for (size_t i = 0; i < ncircuits.size(); i++) {
       int nq = num_qubits[i];
 
       // (#679) Just ignore empty program
       if (ncircuits[i].channels.empty()) {
-        for (int j = 0; j < pauli_sums[i].size(); j++) {
+        for (size_t j = 0; j < pauli_sums[i].size(); j++) {
           (*output_tensor)(i, j) = -2.0;
         }
         continue;
@@ -224,7 +224,7 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
                              sv, unused_stats);
 
         // Use this trajectory as a source for all expectation calculations.
-        for (int j = 0; j < pauli_sums[i].size(); j++) {
+        for (size_t j = 0; j < pauli_sums[i].size(); j++) {
           if (run_samples[j] >= num_samples[i][j]) {
             continue;
           }
@@ -236,14 +236,14 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
           run_samples[j]++;
         }
         bool break_loop = true;
-        for (int j = 0; j < num_samples[i].size(); j++) {
+        for (size_t j = 0; j < num_samples[i].size(); j++) {
           if (run_samples[j] < num_samples[i][j]) {
             break_loop = false;
             break;
           }
         }
         if (break_loop) {
-          for (int j = 0; j < num_samples[i].size(); j++) {
+          for (size_t j = 0; j < num_samples[i].size(); j++) {
             rolling_sums[j] /= num_samples[i][j];
             (*output_tensor)(i, j) = static_cast<float>(rolling_sums[j]);
           }
@@ -285,8 +285,8 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
     tensorflow::GuardedPhiloxRandom random_gen;
     int max_psum_length = 1;
     int max_n_shots = 1;
-    for (int i = 0; i < pauli_sums.size(); i++) {
-      for (int j = 0; j < pauli_sums[i].size(); j++) {
+    for (size_t i = 0; i < pauli_sums.size(); i++) {
+      for (size_t j = 0; j < pauli_sums[i].size(); j++) {
         max_psum_length =
             std::max(max_psum_length, pauli_sums[i][j].terms().size());
         max_n_shots = std::max(max_n_shots, num_samples[i][j]);
@@ -310,13 +310,13 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
       auto local_gen = random_gen.ReserveSamples128(num_rand);
       tensorflow::random::SimplePhilox rand_source(&local_gen);
 
-      for (int i = 0; i < ncircuits.size(); i++) {
+      for (size_t i = 0; i < ncircuits.size(); i++) {
         int nq = num_qubits[i];
         int rep_offset = rep_offsets[start][i];
 
         // (#679) Just ignore empty program
         if (ncircuits[i].channels.empty()) {
-          for (int j = 0; j < pauli_sums[i].size(); j++) {
+          for (size_t j = 0; j < pauli_sums[i].size(); j++) {
             (*output_tensor)(i, j) = -2.0;
           }
           continue;
@@ -343,7 +343,7 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
                                sim, sv, unused_stats);
 
           // Compute expectations across all ops using this trajectory.
-          for (int j = 0; j < pauli_sums[i].size(); j++) {
+          for (size_t j = 0; j < pauli_sums[i].size(); j++) {
             int p_reps = (num_samples[i][j] + num_threads - 1) / num_threads;
             if (run_samples[j] >= p_reps + rep_offset) {
               continue;
@@ -360,7 +360,7 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
 
           // Check if we have run enough trajectories for all ops.
           bool break_loop = true;
-          for (int j = 0; j < num_samples[i].size(); j++) {
+          for (size_t j = 0; j < num_samples[i].size(); j++) {
             int p_reps = (num_samples[i][j] + num_threads - 1) / num_threads;
             if (run_samples[j] < p_reps + rep_offset) {
               break_loop = false;
@@ -370,7 +370,7 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
           if (break_loop) {
             // Lock writing to this batch index in output_tensor.
             batch_locks[i].lock();
-            for (int j = 0; j < num_samples[i].size(); j++) {
+            for (size_t j = 0; j < num_samples[i].size(); j++) {
               rolling_sums[j] /= num_samples[i][j];
               (*output_tensor)(i, j) += static_cast<float>(rolling_sums[j]);
             }

--- a/tensorflow_quantum/core/ops/noise/tfq_noisy_samples.cc
+++ b/tensorflow_quantum/core/ops/noise/tfq_noisy_samples.cc
@@ -159,7 +159,7 @@ class TfqNoisySamplesOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as nescessary.
-    for (int i = 0; i < ncircuits.size(); i++) {
+    for (size_t i = 0; i < ncircuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -252,7 +252,7 @@ class TfqNoisySamplesOp : public tensorflow::OpKernel {
       auto local_gen = random_gen.ReserveSamples32(needed_random);
       tensorflow::random::SimplePhilox rand_source(&local_gen);
 
-      for (int i = 0; i < ncircuits.size(); i++) {
+      for (size_t i = 0; i < ncircuits.size(); i++) {
         int nq = num_qubits[i];
         int j = start > 0 ? offset_prefix_sum[start - 1][i] : 0;
         int needed_samples = offset_prefix_sum[start][i] - j;

--- a/tensorflow_quantum/core/ops/parse_context.cc
+++ b/tensorflow_quantum/core/ops/parse_context.cc
@@ -121,7 +121,8 @@ Status ParsePrograms2D(OpKernelContext* context, const std::string& input_name,
   auto p_lock = tensorflow::mutex();
   auto DoWork = [&](int start, int end) {
     for (int i = start; i < end; i++) {
-      Status local = ParseProto(program_strings(i / num_entries, i % num_entries),
+      Status local =
+          ParseProto(program_strings(i / num_entries, i % num_entries),
                      &programs->at(i / num_entries).at(i % num_entries));
       NESTED_FN_STATUS_SYNC(parse_status, local, p_lock);
     }
@@ -195,11 +196,11 @@ Status GetProgramsAndNumQubits(
       unsigned int this_num_qubits;
       Status local;
       if (p_sums) {
-        local = ResolveQubitIds(&program, &this_num_qubits,
-                                       &(p_sums->at(i)), swap_endianness);
+        local = ResolveQubitIds(&program, &this_num_qubits, &(p_sums->at(i)),
+                                swap_endianness);
       } else {
-        local = ResolveQubitIds(&program, &this_num_qubits,
-                                       nullptr, swap_endianness);
+        local = ResolveQubitIds(&program, &this_num_qubits, nullptr,
+                                swap_endianness);
       }
       NESTED_FN_STATUS_SYNC(parse_status, local, p_lock);
       (*num_qubits)[i] = this_num_qubits;
@@ -247,8 +248,8 @@ tensorflow::Status GetProgramsAndNumQubits(
     for (int i = start; i < end; i++) {
       Program& program = (*programs)[i];
       unsigned int this_num_qubits;
-      Status local = ResolveQubitIds(&program, &this_num_qubits,
-                                              &(*other_programs)[i]);
+      Status local =
+          ResolveQubitIds(&program, &this_num_qubits, &(*other_programs)[i]);
       NESTED_FN_STATUS_SYNC(parse_status, local, p_lock);
       (*num_qubits)[i] = this_num_qubits;
     }

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
@@ -202,7 +202,7 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
         }
 
         ss.SetStateZero(sv);
-        for (int j = 0; j < full_fuse[i].size(); j++) {
+        for (size_t j = 0; j < full_fuse[i].size(); j++) {
           qsim::ApplyFusedGate(sim, full_fuse[i][j], sv);
         }
 
@@ -231,13 +231,13 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
           // if applicable compute control qubit mask and control value bits.
           uint64_t mask = 0;
           uint64_t cbits = 0;
-          for (int k = 0; k < cur_gate.controlled_by.size(); k++) {
+          for (size_t k = 0; k < cur_gate.controlled_by.size(); k++) {
             uint64_t control_loc = cur_gate.controlled_by[k];
             mask |= uint64_t{1} << control_loc;
             cbits |= ((cur_gate.cmask >> k) & 1) << control_loc;
           }
 
-          for (int k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
+          for (size_t k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
             // Copy sv onto scratch2 in anticipation of non-unitary "gradient
             // gate".
             ss.Copy(sv, scratch2);
@@ -297,7 +297,7 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
     auto scratch = ss.Create(largest_nq);
     auto scratch2 = ss.Create(largest_nq);
 
-    for (int i = 0; i < partial_fused_circuits.size(); i++) {
+    for (size_t i = 0; i < partial_fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -314,7 +314,7 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
       }
 
       ss.SetStateZero(sv);
-      for (int j = 0; j < full_fuse[i].size(); j++) {
+      for (size_t j = 0; j < full_fuse[i].size(); j++) {
         qsim::ApplyFusedGate(sim, full_fuse[i][j], sv);
       }
 
@@ -342,13 +342,13 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
         // if applicable compute control qubit mask and control value bits.
         uint64_t mask = 0;
         uint64_t cbits = 0;
-        for (int k = 0; k < cur_gate.controlled_by.size(); k++) {
+        for (size_t k = 0; k < cur_gate.controlled_by.size(); k++) {
           uint64_t control_loc = cur_gate.controlled_by[k];
           mask |= uint64_t{1} << control_loc;
           cbits |= ((cur_gate.cmask >> k) & 1) << control_loc;
         }
 
-        for (int k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
+        for (size_t k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
           // Copy sv onto scratch2 in anticipation of non-unitary "gradient
           // gate".
           ss.Copy(sv, scratch2);

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
@@ -209,8 +209,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
         // sv now contains psi
         // scratch contains (sum_j paulis_sums[i][j] * downstream_grads[j])|psi>
         // scratch2 now contains psi as well.
-        Status unused = AccumulateOperators(pauli_sums[i], downstream_grads[i],
-                                            sim, ss, sv, scratch2, scratch);
+        [[maybe_unused]] AccumulateOperators(pauli_sums[i], downstream_grads[i],
+                                             sim, ss, sv, scratch2, scratch);
 
         for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {
           for (int k = partial_fused_circuits[i][j].size() - 1; k >= 0; k--) {
@@ -237,7 +237,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
             cbits |= ((cur_gate.cmask >> k) & 1) << control_loc;
           }
 
-          for (size_t k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
+          for (size_t k = 0; k < gradient_gates[i][j - 1].grad_gates.size();
+               k++) {
             // Copy sv onto scratch2 in anticipation of non-unitary "gradient
             // gate".
             ss.Copy(sv, scratch2);
@@ -321,8 +322,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
       // sv now contains psi
       // scratch contains (sum_j paulis_sums[i][j] * downstream_grads[j])|psi>
       // scratch2 now contains psi as well.
-      Status unused = AccumulateOperators(pauli_sums[i], downstream_grads[i],
-                                          sim, ss, sv, scratch2, scratch);
+      [[maybe_unused]] AccumulateOperators(pauli_sums[i], downstream_grads[i],
+                                           sim, ss, sv, scratch2, scratch);
 
       for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {
         for (int k = partial_fused_circuits[i][j].size() - 1; k >= 0; k--) {
@@ -348,7 +349,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
           cbits |= ((cur_gate.cmask >> k) & 1) << control_loc;
         }
 
-        for (size_t k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
+        for (size_t k = 0; k < gradient_gates[i][j - 1].grad_gates.size();
+             k++) {
           // Copy sv onto scratch2 in anticipation of non-unitary "gradient
           // gate".
           ss.Copy(sv, scratch2);

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.cu.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.cu.cc
@@ -22,7 +22,7 @@ limitations under the License.
 #include "../qsim/lib/gate_appl.h"
 #include "../qsim/lib/gates_cirq.h"
 #include "../qsim/lib/seqfor.h"
-#include "../qsim/lib/simmux.h"
+#include "../qsim/lib/simmux_gpu.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/shape_inference.h"
 #include "tensorflow/core/framework/tensor_shape.h"
@@ -38,6 +38,41 @@ limitations under the License.
 
 namespace tfq {
 
+namespace {
+  // TODO(jaeyoo): Temorary hack for BulkSetAmpl with cuda ops.
+  // Updates qsim custatevec side BulkSetAmple ops, and remove these utilities.
+  template <typename FP, unsigned warp_size = 32>
+__global__ void BulkSetAmplKernel(
+    uint64_t mask, uint64_t bits, FP re, FP im, bool exclude, FP* state) {
+  uint64_t k1 = uint64_t{blockIdx.x} * blockDim.x + threadIdx.x;
+  uint64_t k2 = 2 * k1 - threadIdx.x % warp_size;
+
+  bool set = ((k1 & mask) == bits) ^ exclude;
+
+  if (set) {
+    state[k2] = re;
+    state[k2 + warp_size] = im;
+  }
+}
+
+// Sets state[i] = complex(re, im) where (i & mask) == bits.
+// if `exclude` is true then the criteria becomes (i & mask) != bits.
+template<typename fp_type>
+void BulkSetAmpl(qsim::SimulatorCuStateVec<float>::StateSpace::State& state,
+                 uint64_t mask, uint64_t bits, fp_type re,
+                 fp_type im, bool exclude = false) {
+  uint64_t size = uint64_t{1} << state.num_qubits();
+
+  unsigned threads = std::min(size, uint64_t{512});
+  unsigned blocks = size / threads;
+
+  BulkSetAmplKernel<<<blocks, threads>>>(
+      mask, bits, re, im, exclude, state.get());
+  cudaPeekAtLastError();
+  cudaDeviceSynchronize();
+}
+} // namespace
+
 using ::tensorflow::Status;
 using ::tfq::proto::PauliSum;
 using ::tfq::proto::Program;
@@ -49,7 +84,17 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
  public:
   explicit TfqAdjointGradientCuquantumOp(
       tensorflow::OpKernelConstruction* context)
-      : OpKernel(context) {}
+      : OpKernel(context) {
+    // create handles for simulator
+    cublasCreate(&cublas_handle_);
+    custatevecCreate(&custatevec_handle_);
+  }
+
+  ~TfqAdjointGradientCuquantumOp() {
+    // destroy handles in sync with simulator lifetime
+    cublasDestroy(cublas_handle_);
+    custatevecDestroy(custatevec_handle_);
+  }
 
   void Compute(tensorflow::OpKernelContext* context) override {
     // TODO (mbbrough): add more dimension checks for other inputs here.
@@ -144,24 +189,10 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
 
     output_tensor.setZero();
 
-    // create handles for simulator
-    cublasCreate(&cublas_handle_);
-    custatevecCreate(&custatevec_handle_);
-    // Cross reference with standard google cloud compute instances
-    // Memory ~= 2 * num_threads * (2 * 64 * 2 ** num_qubits in circuits)
-    // e2s2 = 2 CPU, 8GB -> Can safely do 25 since Memory = 4GB
-    // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
-    // ...
-    // This method creates 3 big state vectors per thread so reducing size
-    // here slightly.
 
     ComputeLarge(num_qubits, qsim_circuits, maps, full_fuse,
                  partial_fused_circuits, pauli_sums, gradient_gates,
                  downstream_grads, context, &output_tensor);
-
-    // destroy handles in sync with simulator lifetime
-    cublasDestroy(cublas_handle_);
-    custatevecDestroy(custatevec_handle_);
   }
 
  private:
@@ -181,7 +212,6 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
       tensorflow::OpKernelContext* context,
       tensorflow::TTypes<float, 1>::Matrix* output_tensor) {
     // Instantiate qsim objects.
-    const auto tfq_for = tfq::QsimFor(context);
     using Simulator = qsim::SimulatorCuStateVec<float>;
     using StateSpace = Simulator::StateSpace;
 
@@ -193,7 +223,7 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
     auto scratch = ss.Create(largest_nq);
     auto scratch2 = ss.Create(largest_nq);
 
-    for (int i = 0; i < partial_fused_circuits.size(); i++) {
+    for (size_t i = 0; i < partial_fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -210,7 +240,7 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
       }
 
       ss.SetStateZero(sv);
-      for (int j = 0; j < full_fuse[i].size(); j++) {
+      for (size_t j = 0; j < full_fuse[i].size(); j++) {
         qsim::ApplyFusedGate(sim, full_fuse[i][j], sv);
       }
 
@@ -238,13 +268,13 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
         // if applicable compute control qubit mask and control value bits.
         uint64_t mask = 0;
         uint64_t cbits = 0;
-        for (int k = 0; k < cur_gate.controlled_by.size(); k++) {
+        for (size_t k = 0; k < cur_gate.controlled_by.size(); k++) {
           uint64_t control_loc = cur_gate.controlled_by[k];
           mask |= uint64_t{1} << control_loc;
           cbits |= ((cur_gate.cmask >> k) & 1) << control_loc;
         }
 
-        for (int k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
+        for (size_t k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
           // Copy sv onto scratch2 in anticipation of non-unitary "gradient
           // gate".
           ss.Copy(sv, scratch2);
@@ -252,7 +282,7 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
             // Gradient of controlled gates puts zeros on diagonal which is
             // the same as collapsing the state and then applying the
             // non-controlled version of the gradient gate.
-            ss.BulkSetAmpl(scratch2, mask, cbits, 0, 0, true);
+            BulkSetAmpl<float>(scratch2, mask, cbits, 0, 0, true);
           }
           qsim::ApplyGate(sim, gradient_gates[i][j - 1].grad_gates[k],
                           scratch2);

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum_test.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum_test.py
@@ -95,8 +95,8 @@ class ADJGradTest(tf.test.TestCase, parameterized.TestCase):
                 circuit_batch_tensor, symbol_names,
                 symbol_values_array.astype(np.float64), pauli_sums_tensor,
                 prev_grads),
-            "CPU",
-            num_samples=100,
+            "Adjoint CPU",
+            num_samples=10,
             result_avg=True,
         )
 
@@ -105,8 +105,8 @@ class ADJGradTest(tf.test.TestCase, parameterized.TestCase):
                 circuit_batch_tensor, symbol_names,
                 symbol_values_array.astype(np.float64), pauli_sums_tensor,
                 prev_grads),
-            "cuQuantum",
-            num_samples=100,
+            "Adjoint cuQuantum",
+            num_samples=10,
             result_avg=True,
         )
 
@@ -116,7 +116,7 @@ class ADJGradTest(tf.test.TestCase, parameterized.TestCase):
         # The result should be the similar within a tolerance.
         np.testing.assert_allclose(res_cpu,
                                    res_cuquantum,
-                                   atol=1e-4,
+                                   atol=1e-3,
                                    err_msg="""
         # If failed, the GPU architecture in this system may be unsupported.
         # Please refer to the supported architectures here.

--- a/tensorflow_quantum/core/ops/tfq_calculate_unitary_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_calculate_unitary_op.cc
@@ -116,7 +116,7 @@ class TfqCalculateUnitaryOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the unitary as nescessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
       UCalculator sim = UCalculator(tfq_for);
       UnitarySpace us = UnitarySpace(tfq_for);
@@ -126,7 +126,7 @@ class TfqCalculateUnitaryOp : public tensorflow::OpKernel {
         u = us.CreateUnitary(nq);
       }
       us.SetIdentity(u);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], u);
       }
 

--- a/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
@@ -54,8 +54,8 @@ class TfqCircuitAppendOp : public tensorflow::OpKernel {
     auto DoWork = [&](int start, int end) {
       std::string temp;
       for (int i = start; i < end; i++) {
-        for (size_t j = 0; j < programs_to_append.at(i).circuit().moments().size();
-             j++) {
+        for (size_t j = 0;
+             j < programs_to_append.at(i).circuit().moments().size(); j++) {
           Moment *new_moment = programs.at(i).mutable_circuit()->add_moments();
           *new_moment = programs_to_append.at(i).circuit().moments(j);
         }

--- a/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
@@ -54,7 +54,7 @@ class TfqCircuitAppendOp : public tensorflow::OpKernel {
     auto DoWork = [&](int start, int end) {
       std::string temp;
       for (int i = start; i < end; i++) {
-        for (int j = 0; j < programs_to_append.at(i).circuit().moments().size();
+        for (size_t j = 0; j < programs_to_append.at(i).circuit().moments().size();
              j++) {
           Moment *new_moment = programs.at(i).mutable_circuit()->add_moments();
           *new_moment = programs_to_append.at(i).circuit().moments(j);

--- a/tensorflow_quantum/core/ops/tfq_ps_decompose_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_ps_decompose_op.cc
@@ -65,11 +65,11 @@ class TfqPsDecomposeOp : public tensorflow::OpKernel {
         new_program.mutable_language()->set_gate_set("tfq_gate_set");
         new_program.mutable_circuit()->set_scheduling_strategy(
             Circuit::MOMENT_BY_MOMENT);
-        for (int j = 0; j < cur_program.circuit().moments().size(); j++) {
+        for (size_t j = 0; j < cur_program.circuit().moments().size(); j++) {
           Moment cur_moment(cur_program.circuit().moments().at(j));
           std::vector<Moment> temp_moment_list(max_buffer_moments, Moment());
           int num_extra_moments = 0;
-          for (int k = 0; k < cur_moment.operations().size(); k++) {
+          for (size_t k = 0; k < cur_moment.operations().size(); k++) {
             Operation cur_op = cur_moment.operations().at(k);
             auto &cur_op_map = *cur_op.mutable_args();
             if (cur_op.gate().id() == "PISP") {

--- a/tensorflow_quantum/core/ops/tfq_ps_symbol_replace_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_ps_symbol_replace_op.cc
@@ -89,9 +89,9 @@ class TfqPsSymbolReplaceOp : public tensorflow::OpKernel {
         std::string symbol_to_replace = symbols(sidx);
         std::string temp_symbol_holder;
         Program cur_program = programs.at(pidx);
-        for (int j = 0; j < cur_program.circuit().moments().size(); j++) {
+        for (size_t j = 0; j < cur_program.circuit().moments().size(); j++) {
           Moment cur_moment = cur_program.circuit().moments().at(j);
-          for (int k = 0; k < cur_moment.operations().size(); k++) {
+          for (size_t k = 0; k < cur_moment.operations().size(); k++) {
             Operation cur_op = cur_moment.operations().at(k);
             for (auto l = cur_op.args().begin(); l != cur_op.args().end();
                  l++) {
@@ -163,11 +163,11 @@ class TfqPsSymbolReplaceOp : public tensorflow::OpKernel {
       for (int i = start; i < end; i++) {
         int sidx = i % n_symbols;
         int pidx = i / n_symbols;
-        for (int j = 0; j < output_programs.at(pidx).at(sidx).size(); j++) {
+        for (size_t j = 0; j < output_programs.at(pidx).at(sidx).size(); j++) {
           output_tensor(pidx, sidx, j) =
               output_programs.at(pidx).at(sidx).at(j);
         }
-        for (int j = output_programs.at(pidx).at(sidx).size(); j < biggest_pad;
+        for (size_t j = output_programs.at(pidx).at(sidx).size(); j < biggest_pad;
              j++) {
           output_tensor(pidx, sidx, j) = empty_program;
         }

--- a/tensorflow_quantum/core/ops/tfq_ps_symbol_replace_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_ps_symbol_replace_op.cc
@@ -167,8 +167,8 @@ class TfqPsSymbolReplaceOp : public tensorflow::OpKernel {
           output_tensor(pidx, sidx, j) =
               output_programs.at(pidx).at(sidx).at(j);
         }
-        for (size_t j = output_programs.at(pidx).at(sidx).size(); j < biggest_pad;
-             j++) {
+        for (size_t j = output_programs.at(pidx).at(sidx).size();
+             j < biggest_pad; j++) {
           output_tensor(pidx, sidx, j) = empty_program;
         }
       }

--- a/tensorflow_quantum/core/ops/tfq_ps_weights_from_symbols_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_ps_weights_from_symbols_op.cc
@@ -82,9 +82,9 @@ class TfqPsWeightsFromSymbolOp : public tensorflow::OpKernel {
     auto DoWork = [&](int start, int end) {
       for (int i = start; i < end; i++) {
         Program cur_program = programs.at(i);
-        for (int j = 0; j < cur_program.circuit().moments().size(); j++) {
+        for (size_t j = 0; j < cur_program.circuit().moments().size(); j++) {
           Moment cur_moment = cur_program.circuit().moments().at(j);
-          for (int k = 0; k < cur_moment.operations().size(); k++) {
+          for (size_t k = 0; k < cur_moment.operations().size(); k++) {
             Operation cur_op = cur_moment.operations().at(k);
             if (ignored_symbol_set.contains(cur_op.gate().id())) continue;
 
@@ -146,10 +146,10 @@ class TfqPsWeightsFromSymbolOp : public tensorflow::OpKernel {
     auto DoWork2 = [&](int start, int end) {
       for (int i = start; i < end; i++) {
         for (int j = 0; j < n_symbols; j++) {
-          for (int k = 0; k < output_results.at(i).at(j).size(); k++) {
+          for (size_t k = 0; k < output_results.at(i).at(j).size(); k++) {
             output_tensor(i, j, k) = output_results.at(i).at(j).at(k);
           }
-          for (int k = output_results.at(i).at(j).size();
+          for (size_t k = output_results.at(i).at(j).size();
                k < largest_single_symbol; k++) {
             output_tensor(i, j, k) = 0.0f;
           }

--- a/tensorflow_quantum/core/ops/tfq_simulate_expectation_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_expectation_op.cc
@@ -143,7 +143,7 @@ class TfqSimulateExpectationOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as necessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -156,10 +156,10 @@ class TfqSimulateExpectationOp : public tensorflow::OpKernel {
       //  the state if there is a possibility that circuit[i] and
       //  circuit[i + 1] produce the same state.
       ss.SetStateZero(sv);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
       }
-      for (int j = 0; j < pauli_sums[i].size(); j++) {
+      for (size_t j = 0; j < pauli_sums[i].size(); j++) {
         // (#679) Just ignore empty program
         if (fused_circuits[i].size() == 0) {
           (*output_tensor)(i, j) = -2.0;
@@ -221,7 +221,7 @@ class TfqSimulateExpectationOp : public tensorflow::OpKernel {
           // no need to update scratch_state since ComputeExpectation
           // will take care of things for us.
           ss.SetStateZero(sv);
-          for (int j = 0; j < fused_circuits[cur_batch_index].size(); j++) {
+          for (size_t j = 0; j < fused_circuits[cur_batch_index].size(); j++) {
             qsim::ApplyFusedGate(sim, fused_circuits[cur_batch_index][j], sv);
           }
         }

--- a/tensorflow_quantum/core/ops/tfq_simulate_expectation_op_cuquantum.cu.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_expectation_op_cuquantum.cu.cc
@@ -153,7 +153,7 @@ class TfqSimulateExpectationOpCuQuantum : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as necessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -166,10 +166,10 @@ class TfqSimulateExpectationOpCuQuantum : public tensorflow::OpKernel {
       //  the state if there is a possibility that circuit[i] and
       //  circuit[i + 1] produce the same state.
       ss.SetStateZero(sv);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
       }
-      for (int j = 0; j < pauli_sums[i].size(); j++) {
+      for (size_t j = 0; j < pauli_sums[i].size(); j++) {
         // (#679) Just ignore empty program
         if (fused_circuits[i].size() == 0) {
           (*output_tensor)(i, j) = -2.0;

--- a/tensorflow_quantum/core/ops/tfq_simulate_sampled_expectation_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_sampled_expectation_op.cc
@@ -177,7 +177,7 @@ class TfqSimulateSampledExpectationOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as necessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -190,10 +190,10 @@ class TfqSimulateSampledExpectationOp : public tensorflow::OpKernel {
       //  the state if there is a possibility that circuit[i] and
       //  circuit[i + 1] produce the same state.
       ss.SetStateZero(sv);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
       }
-      for (int j = 0; j < pauli_sums[i].size(); j++) {
+      for (size_t j = 0; j < pauli_sums[i].size(); j++) {
         // (#679) Just ignore empty program
         if (fused_circuits[i].size() == 0) {
           (*output_tensor)(i, j) = -2.0;
@@ -273,7 +273,7 @@ class TfqSimulateSampledExpectationOp : public tensorflow::OpKernel {
           // no need to update scratch_state since ComputeExpectation
           // will take care of things for us.
           ss.SetStateZero(sv);
-          for (int j = 0; j < fused_circuits[cur_batch_index].size(); j++) {
+          for (size_t j = 0; j < fused_circuits[cur_batch_index].size(); j++) {
             qsim::ApplyFusedGate(sim, fused_circuits[cur_batch_index][j], sv);
           }
         }

--- a/tensorflow_quantum/core/ops/tfq_simulate_samples_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_samples_op.cc
@@ -156,7 +156,7 @@ class TfqSimulateSamplesOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as nescessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -165,7 +165,7 @@ class TfqSimulateSamplesOp : public tensorflow::OpKernel {
         sv = ss.Create(largest_nq);
       }
       ss.SetStateZero(sv);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
       }
 
@@ -218,7 +218,7 @@ class TfqSimulateSamplesOp : public tensorflow::OpKernel {
           sv = ss.Create(largest_nq);
         }
         ss.SetStateZero(sv);
-        for (int j = 0; j < fused_circuits[i].size(); j++) {
+        for (size_t j = 0; j < fused_circuits[i].size(); j++) {
           qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
         }
 

--- a/tensorflow_quantum/core/ops/tfq_simulate_samples_op_cuquantum.cu.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_samples_op_cuquantum.cu.cc
@@ -158,7 +158,7 @@ class TfqSimulateSamplesOpCuQuantum : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as nescessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -167,7 +167,7 @@ class TfqSimulateSamplesOpCuQuantum : public tensorflow::OpKernel {
         sv = ss.Create(largest_nq);
       }
       ss.SetStateZero(sv);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
       }
 

--- a/tensorflow_quantum/core/ops/tfq_simulate_state_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_state_op.cc
@@ -136,7 +136,7 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as necessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -145,7 +145,7 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
         sv = ss.Create(largest_nq);
       }
       ss.SetStateZero(sv);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
       }
 
@@ -194,7 +194,7 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
           sv = ss.Create(largest_nq);
         }
         ss.SetStateZero(sv);
-        for (int j = 0; j < fused_circuits[i].size(); j++) {
+        for (size_t j = 0; j < fused_circuits[i].size(); j++) {
           qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
         }
 

--- a/tensorflow_quantum/core/ops/tfq_simulate_state_op_cuquantum.cu.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_state_op_cuquantum.cu.cc
@@ -145,7 +145,7 @@ class TfqSimulateStateOpCuQuantum : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as necessary.
-    for (int i = 0; i < fused_circuits.size(); i++) {
+    for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 
       if (nq > largest_nq) {
@@ -155,7 +155,7 @@ class TfqSimulateStateOpCuQuantum : public tensorflow::OpKernel {
         sv_host.resize(2 * (uint64_t(1) << largest_nq));
       }
       ss.SetStateZero(sv);
-      for (int j = 0; j < fused_circuits[i].size(); j++) {
+      for (size_t j = 0; j < fused_circuits[i].size(); j++) {
         qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
       }
 

--- a/tensorflow_quantum/core/serialize/op_deserializer_test.py
+++ b/tensorflow_quantum/core/serialize/op_deserializer_test.py
@@ -38,7 +38,7 @@ def op_proto(json_dict):
 
 
 @cirq.value_equality
-class GateWithAttribute(cirq.SingleQubitGate):
+class GateWithAttribute(cirq.testing.SingleQubitGate):
     """GateAttribute helper class."""
 
     def __init__(self, val, not_req=None):

--- a/tensorflow_quantum/core/serialize/op_serializer_test.py
+++ b/tensorflow_quantum/core/serialize/op_serializer_test.py
@@ -38,14 +38,14 @@ def op_proto(json):
     return op
 
 
-class GateWithAttribute(cirq.SingleQubitGate):
+class GateWithAttribute(cirq.testing.SingleQubitGate):
     """GateAttribute helper class."""
 
     def __init__(self, val):
         self.val = val
 
 
-class GateWithProperty(cirq.SingleQubitGate):
+class GateWithProperty(cirq.testing.SingleQubitGate):
     """GateProperty helper class."""
 
     def __init__(self, val, not_req=None):
@@ -58,7 +58,7 @@ class GateWithProperty(cirq.SingleQubitGate):
         return self._val
 
 
-class GateWithMethod(cirq.SingleQubitGate):
+class GateWithMethod(cirq.testing.SingleQubitGate):
     """GateMethod helper class."""
 
     def __init__(self, val):

--- a/tensorflow_quantum/core/src/adj_util.cc
+++ b/tensorflow_quantum/core/src/adj_util.cc
@@ -38,7 +38,7 @@ void CreateGradientCircuit(
     const QsimCircuit& circuit, const std::vector<GateMetaData>& metadata,
     std::vector<std::vector<qsim::GateFused<QsimGate>>>* partial_fuses,
     std::vector<GradientOfGate>* grad_gates) {
-  for (int i = 0; i < metadata.size(); i++) {
+  for (size_t i = 0; i < metadata.size(); i++) {
     if (metadata[i].symbol_values.empty()) {
       continue;
     }
@@ -78,7 +78,7 @@ void CreateGradientCircuit(
     // PhasedX
     else if (circuit.gates[i].kind == qsim::Cirq::GateKind::kPhasedXPowGate) {
       // Process potentially several symbols.
-      for (int j = 0; j < metadata[i].symbol_values.size(); j++) {
+      for (size_t j = 0; j < metadata[i].symbol_values.size(); j++) {
         if (metadata[i].placeholder_names[j] ==
             GateParamNames::kPhaseExponent) {
           PopulateGradientPhasedXPhasedExponent(
@@ -103,7 +103,7 @@ void CreateGradientCircuit(
       // Process potentially several symbols.
 
       bool swapq = circuit.gates[i].swapped;
-      for (int j = 0; j < metadata[i].symbol_values.size(); j++) {
+      for (size_t j = 0; j < metadata[i].symbol_values.size(); j++) {
         if (metadata[i].placeholder_names[j] == GateParamNames::kTheta) {
           PopulateGradientFsimTheta(
               metadata[i].symbol_values[j], i,
@@ -128,7 +128,7 @@ void CreateGradientCircuit(
              qsim::Cirq::GateKind::kPhasedISwapPowGate) {
       // Process potentially several symbols.
       bool swapq = circuit.gates[i].swapped;
-      for (int j = 0; j < metadata[i].symbol_values.size(); j++) {
+      for (size_t j = 0; j < metadata[i].symbol_values.size(); j++) {
         if (metadata[i].placeholder_names[j] ==
             GateParamNames::kPhaseExponent) {
           PopulateGradientPhasedISwapPhasedExponent(
@@ -159,7 +159,7 @@ void CreateGradientCircuit(
 
   partial_fuses->assign(grad_gates->size() + 1,
                         std::vector<qsim::GateFused<QsimGate>>({}));
-  for (int i = 0; i < grad_gates->size(); i++) {
+  for (size_t i = 0; i < grad_gates->size(); i++) {
     right = circuit.gates.begin() + (*grad_gates)[i].index;
     (*partial_fuses)[i] =
         fuser.FuseGates(qsim::BasicGateFuser<qsim::IO, QsimGate>::Parameter(),

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.cc
@@ -187,8 +187,8 @@ inline Status TwoConstantGate(
     const unsigned int num_qubits, const unsigned int time,
     QsimCircuit* circuit, std::vector<GateMetaData>* metadata) {
   unsigned int q0, q1;
-  bool unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
-  unused = absl::SimpleAtoi(op.qubits(1).id(), &q1);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(1).id(), &q1);
   auto gate = create_f(time, num_qubits - q0 - 1, num_qubits - q1 - 1);
   Status s = OptionalInsertControls(op, num_qubits, &gate);
   if (!s.ok()) {
@@ -213,10 +213,10 @@ inline Status SingleEigenGate(
     const unsigned int num_qubits, const unsigned int time,
     QsimCircuit* circuit, std::vector<GateMetaData>* metadata) {
   unsigned int q0;
-  bool unused;
+
   float exp, exp_s, gs;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
 
   absl::optional<std::string> exponent_symbol;
   u = ParseProtoArg(op, "exponent", param_map, &exp, &exponent_symbol);
@@ -263,10 +263,10 @@ inline Status TwoEigenGate(
     QsimCircuit* circuit, std::vector<GateMetaData>* metadata) {
   unsigned int q0, q1;
   float exp, exp_s, gs;
-  bool unused;
+
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
-  unused = absl::SimpleAtoi(op.qubits(1).id(), &q1);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(1).id(), &q1);
 
   absl::optional<std::string> exponent_symbol;
   u = ParseProtoArg(op, "exponent", param_map, &exp, &exponent_symbol);
@@ -402,10 +402,10 @@ inline Status PhasedXGate(const Operation& op, const SymbolMap& param_map,
                           const unsigned int time, QsimCircuit* circuit,
                           std::vector<GateMetaData>* metadata) {
   int q0;
-  bool unused;
+
   float pexp, pexp_s, exp, exp_s, gs;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
 
   absl::optional<std::string> exponent_symbol;
   u = ParseProtoArg(op, "exponent", param_map, &exp, &exponent_symbol);
@@ -462,11 +462,11 @@ inline Status FsimGate(const Operation& op, const SymbolMap& param_map,
                        QsimCircuit* circuit,
                        std::vector<GateMetaData>* metadata) {
   int q0, q1;
-  bool unused;
+
   float theta, theta_s, phi, phi_s;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
-  unused = absl::SimpleAtoi(op.qubits(1).id(), &q1);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(1).id(), &q1);
 
   absl::optional<std::string> theta_symbol;
   u = ParseProtoArg(op, "theta", param_map, &theta, &theta_symbol);
@@ -519,11 +519,11 @@ inline Status PhasedISwapGate(const Operation& op, const SymbolMap& param_map,
                               const unsigned int time, QsimCircuit* circuit,
                               std::vector<GateMetaData>* metadata) {
   int q0, q1;
-  bool unused;
+
   float pexp, pexp_s, exp, exp_s;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
-  unused = absl::SimpleAtoi(op.qubits(1).id(), &q1);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(1).id(), &q1);
 
   absl::optional<std::string> exponent_symbol;
   u = ParseProtoArg(op, "exponent", param_map, &exp, &exponent_symbol);
@@ -611,10 +611,10 @@ inline Status AsymmetricDepolarizingChannel(const Operation& op,
                                             const unsigned int time,
                                             NoisyQsimCircuit* ncircuit) {
   int q;
-  bool unused;
+
   float p_x, p_y, p_z;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p_x", {}, &p_x);
   u = ParseProtoArg(op, "p_y", {}, &p_y);
@@ -633,10 +633,10 @@ inline Status DepolarizingChannel(const Operation& op,
                                   const unsigned int time,
                                   NoisyQsimCircuit* ncircuit) {
   int q;
-  bool unused;
+
   float p;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p", {}, &p);
   if (!u.ok()) {
@@ -651,10 +651,10 @@ inline Status DepolarizingChannel(const Operation& op,
 inline Status GADChannel(const Operation& op, const unsigned int num_qubits,
                          const unsigned int time, NoisyQsimCircuit* ncircuit) {
   int q;
-  bool unused;
+
   float p, gamma;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p", {}, &p);
   if (!u.ok()) {
@@ -675,8 +675,8 @@ inline Status ResetChannel(const Operation& op, const unsigned int num_qubits,
                            const unsigned int time,
                            NoisyQsimCircuit* ncircuit) {
   int q;
-  bool unused;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
+
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   auto chan = qsim::Cirq::ResetChannel<float>::Create(time, num_qubits - q - 1);
   ncircuit->channels.push_back(chan);
@@ -688,10 +688,10 @@ inline Status AmplitudeDampingChannel(const Operation& op,
                                       const unsigned int time,
                                       NoisyQsimCircuit* ncircuit) {
   int q;
-  bool unused;
+
   float gamma;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "gamma", {}, &gamma);
   if (!u.ok()) {
@@ -708,10 +708,10 @@ inline Status PhaseDampingChannel(const Operation& op,
                                   const unsigned int time,
                                   NoisyQsimCircuit* ncircuit) {
   int q;
-  bool unused;
+
   float gamma;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "gamma", {}, &gamma);
   if (!u.ok()) {
@@ -729,10 +729,10 @@ inline Status PhaseFlipChannel(const Operation& op,
                                const unsigned int time,
                                NoisyQsimCircuit* ncircuit) {
   int q;
-  bool unused;
+
   float p;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p", {}, &p);
   if (!u.ok()) {
@@ -749,10 +749,10 @@ inline Status BitFlipChannel(const Operation& op, const unsigned int num_qubits,
                              const unsigned int time,
                              NoisyQsimCircuit* ncircuit) {
   int q;
-  bool unused;
+
   float p;
   Status u;
-  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p", {}, &p);
   if (!u.ok()) {
@@ -852,7 +852,7 @@ tensorflow::Status QsimCircuitFromProgram(
   // Convert proto to qsim internal representation.
   circuit->num_qubits = num_qubits;
   int time = 0;
-  bool unused;
+
   // Special case empty.
   if (num_qubits <= 0) {
     return ::tensorflow::Status();

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.cc
@@ -187,8 +187,9 @@ inline Status TwoConstantGate(
     const unsigned int num_qubits, const unsigned int time,
     QsimCircuit* circuit, std::vector<GateMetaData>* metadata) {
   unsigned int q0, q1;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(1).id(), &q1);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  unused = absl::SimpleAtoi(op.qubits(1).id(), &q1);
   auto gate = create_f(time, num_qubits - q0 - 1, num_qubits - q1 - 1);
   Status s = OptionalInsertControls(op, num_qubits, &gate);
   if (!s.ok()) {
@@ -216,7 +217,8 @@ inline Status SingleEigenGate(
 
   float exp, exp_s, gs;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
 
   absl::optional<std::string> exponent_symbol;
   u = ParseProtoArg(op, "exponent", param_map, &exp, &exponent_symbol);
@@ -265,8 +267,9 @@ inline Status TwoEigenGate(
   float exp, exp_s, gs;
 
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(1).id(), &q1);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  unused = absl::SimpleAtoi(op.qubits(1).id(), &q1);
 
   absl::optional<std::string> exponent_symbol;
   u = ParseProtoArg(op, "exponent", param_map, &exp, &exponent_symbol);
@@ -405,7 +408,8 @@ inline Status PhasedXGate(const Operation& op, const SymbolMap& param_map,
 
   float pexp, pexp_s, exp, exp_s, gs;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
 
   absl::optional<std::string> exponent_symbol;
   u = ParseProtoArg(op, "exponent", param_map, &exp, &exponent_symbol);
@@ -465,8 +469,9 @@ inline Status FsimGate(const Operation& op, const SymbolMap& param_map,
 
   float theta, theta_s, phi, phi_s;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(1).id(), &q1);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  unused = absl::SimpleAtoi(op.qubits(1).id(), &q1);
 
   absl::optional<std::string> theta_symbol;
   u = ParseProtoArg(op, "theta", param_map, &theta, &theta_symbol);
@@ -522,8 +527,9 @@ inline Status PhasedISwapGate(const Operation& op, const SymbolMap& param_map,
 
   float pexp, pexp_s, exp, exp_s;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q0);
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(1).id(), &q1);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q0);
+  unused = absl::SimpleAtoi(op.qubits(1).id(), &q1);
 
   absl::optional<std::string> exponent_symbol;
   u = ParseProtoArg(op, "exponent", param_map, &exp, &exponent_symbol);
@@ -614,7 +620,8 @@ inline Status AsymmetricDepolarizingChannel(const Operation& op,
 
   float p_x, p_y, p_z;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p_x", {}, &p_x);
   u = ParseProtoArg(op, "p_y", {}, &p_y);
@@ -636,7 +643,8 @@ inline Status DepolarizingChannel(const Operation& op,
 
   float p;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p", {}, &p);
   if (!u.ok()) {
@@ -654,7 +662,8 @@ inline Status GADChannel(const Operation& op, const unsigned int num_qubits,
 
   float p, gamma;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p", {}, &p);
   if (!u.ok()) {
@@ -676,7 +685,8 @@ inline Status ResetChannel(const Operation& op, const unsigned int num_qubits,
                            NoisyQsimCircuit* ncircuit) {
   int q;
 
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   auto chan = qsim::Cirq::ResetChannel<float>::Create(time, num_qubits - q - 1);
   ncircuit->channels.push_back(chan);
@@ -691,7 +701,8 @@ inline Status AmplitudeDampingChannel(const Operation& op,
 
   float gamma;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "gamma", {}, &gamma);
   if (!u.ok()) {
@@ -711,7 +722,8 @@ inline Status PhaseDampingChannel(const Operation& op,
 
   float gamma;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "gamma", {}, &gamma);
   if (!u.ok()) {
@@ -732,7 +744,8 @@ inline Status PhaseFlipChannel(const Operation& op,
 
   float p;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p", {}, &p);
   if (!u.ok()) {
@@ -752,7 +765,8 @@ inline Status BitFlipChannel(const Operation& op, const unsigned int num_qubits,
 
   float p;
   Status u;
-  [[maybe_unused]] absl::SimpleAtoi(op.qubits(0).id(), &q);
+  [[maybe_unused]] bool unused;
+  unused = absl::SimpleAtoi(op.qubits(0).id(), &q);
 
   u = ParseProtoArg(op, "p", {}, &p);
   if (!u.ok()) {
@@ -852,6 +866,7 @@ tensorflow::Status QsimCircuitFromProgram(
   // Convert proto to qsim internal representation.
   circuit->num_qubits = num_qubits;
   int time = 0;
+  [[maybe_unused]] bool unused;
 
   // Special case empty.
   if (num_qubits <= 0) {

--- a/tensorflow_quantum/core/src/circuit_parser_qsim_test.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim_test.cc
@@ -65,7 +65,7 @@ Arg MakeControlArg(const std::string& val) {
 }
 
 inline void AssertControlEqual(const QsimGate& a, const QsimGate& b) {
-  for (int i = 0; i < a.controlled_by.size(); i++) {
+  for (size_t i = 0; i < a.controlled_by.size(); i++) {
     ASSERT_EQ(a.controlled_by[i], b.controlled_by[i]);
   }
   ASSERT_EQ(a.cmask, b.cmask);
@@ -90,14 +90,14 @@ inline void AssertOneQubitEqual(const QsimGate& a, const QsimGate& b) {
 
 inline void AssertChannelEqual(const QsimChannel& a, const QsimChannel& b) {
   ASSERT_EQ(a.size(), b.size());
-  for (int i = 0; i < a.size(); i++) {
+  for (size_t i = 0; i < a.size(); i++) {
     ASSERT_EQ(a[i].kind, b[i].kind);
     ASSERT_EQ(a[i].unitary, b[i].unitary);
     ASSERT_NEAR(a[i].prob, b[i].prob, 1e-5);
     auto a_k_ops = a[i].ops;
     auto b_k_ops = b[i].ops;
     EXPECT_EQ(a_k_ops.size(), b_k_ops.size());
-    for (int j = 0; j < a_k_ops.size(); j++) {
+    for (size_t j = 0; j < a_k_ops.size(); j++) {
       AssertOneQubitEqual(a_k_ops[j], b_k_ops[j]);
     }
   }

--- a/tensorflow_quantum/core/src/program_resolution.cc
+++ b/tensorflow_quantum/core/src/program_resolution.cc
@@ -373,7 +373,7 @@ Status CheckMPSSupported(const Program& program) {
       }
 
       if (total_num_qubits == 2) {
-        int j = 0;
+        size_t j = 0;
         std::vector<int> qids(2, -1234);
         for (; j < qubits.size(); j++) {
           (void)absl::SimpleAtoi(qubits[j].id(), &qids[j]);

--- a/tensorflow_quantum/core/src/util_qsim.h
+++ b/tensorflow_quantum/core/src/util_qsim.h
@@ -453,13 +453,13 @@ static void BalanceTrajectory(const std::vector<std::vector<int>>& num_samples,
   std::vector<int> rep_limits(num_samples.size(), -1);
   std::vector<int> height(num_threads, 0);
 
-  for (int i = 0; i < num_samples.size(); i++) {
-    for (int j = 0; j < num_samples[i].size(); j++) {
+  for (size_t i = 0; i < num_samples.size(); i++) {
+    for (size_t j = 0; j < num_samples[i].size(); j++) {
       rep_limits[i] = std::max(rep_limits[i], num_samples[i][j]);
     }
   }
   int prev_max_height = -1;
-  for (int j = 0; j < num_samples.size(); j++) {
+  for (size_t j = 0; j < num_samples.size(); j++) {
     int run_ceiling = ((rep_limits[j] + num_threads - 1) / num_threads);
     int num_lo = num_threads * run_ceiling - rep_limits[j];
     int num_hi = num_threads - num_lo;
@@ -498,7 +498,7 @@ static void BalanceTrajectory(const int& num_samples, const int& num_threads,
   std::vector<int> height(num_threads, 0);
 
   int prev_max_height = -1;
-  for (int j = 0; j < (*thread_offsets)[0].size(); j++) {
+  for (size_t j = 0; j < (*thread_offsets)[0].size(); j++) {
     int run_ceiling = ((num_samples + num_threads - 1) / num_threads);
     int num_lo = num_threads * run_ceiling - num_samples;
     int num_hi = num_threads - num_lo;

--- a/tensorflow_quantum/core/src/util_qsim_test.cc
+++ b/tensorflow_quantum/core/src/util_qsim_test.cc
@@ -646,13 +646,13 @@ static void AssertWellBalanced(const std::vector<std::vector<int>>& n_reps,
                                const int& num_threads,
                                const std::vector<std::vector<int>>& offsets) {
   auto max_work = std::vector<int>(n_reps.size(), -1);
-  for (int i = 0; i < n_reps.size(); i++) {
-    for (int j = 0; j < n_reps[0].size(); j++) {
+  for (size_t i = 0; i < n_reps.size(); i++) {
+    for (size_t j = 0; j < n_reps[0].size(); j++) {
       max_work[i] = std::max(max_work[i], n_reps[i][j]);
     }
   }
 
-  for (int i = 0; i < n_reps.size(); i++) {
+  for (size_t i = 0; i < n_reps.size(); i++) {
     int sum = 0;
     int prev_local_work = 0;
     for (int k = 0; k < num_threads; k++) {

--- a/tensorflow_quantum/datasets/spin_system_test.py
+++ b/tensorflow_quantum/datasets/spin_system_test.py
@@ -27,7 +27,8 @@ from tensorflow_quantum.datasets import spin_system
 from tensorflow_quantum.datasets.spin_system import SpinSystemInfo
 
 
-class TFIChainTest(tf.test.TestCase):
+# TODO(#748): Inherit this class from tf.test.TestCase after fixing the issue.
+class TFIRectangularTest:
     """Testing tfi_chain."""
     # pylint: disable=C0103
 

--- a/tensorflow_quantum/datasets/spin_system_test.py
+++ b/tensorflow_quantum/datasets/spin_system_test.py
@@ -28,7 +28,7 @@ from tensorflow_quantum.datasets.spin_system import SpinSystemInfo
 
 
 # TODO(#748): Inherit this class from tf.test.TestCase after fixing the issue.
-class TFIRectangularTest:
+class TFIChainTest:
     """Testing tfi_chain."""
     # pylint: disable=C0103
 

--- a/tensorflow_quantum/python/differentiators/adjoint.py
+++ b/tensorflow_quantum/python/differentiators/adjoint.py
@@ -33,9 +33,10 @@ class Adjoint(differentiator.Differentiator):
     https://academic.oup.com/gji/article-pdf/167/2/495/1492368/167-2-495.pdf).
     The Adjoint method differentiates the input circuits in roughly one forward
     and backward pass over the circuits, to calculate the gradient of
-    a symbol only a constant number of gate operations need to be applied to the
-    circuits state. When the number of parameters in a circuit is very large,
-    this differentiator performs much better than all the others found in TFQ.
+    a symbol only a constant number of gate operations need to be applied to
+    the circuits state. When the number of parameters in a circuit is very
+    large, this differentiator performs much better than all the others found
+    in TFQ.
 
 
     >>> my_op = tfq.get_expectation_op()
@@ -114,6 +115,7 @@ class Adjoint(differentiator.Differentiator):
             forward_pass_vals,
             grad,
     ):
+        """Returns cuquantum adjoint gradient op result."""
         return tfq_adj_grad_op_cuquantum.tfq_adj_grad(programs, symbol_names,
                                                       symbol_values, pauli_sums,
                                                       grad)
@@ -129,6 +131,7 @@ class Adjoint(differentiator.Differentiator):
             forward_pass_vals,
             grad,
     ):
+        """Returns cpu adjoint gradient op result."""
         return tfq_adj_grad_op.tfq_adj_grad(programs, symbol_names,
                                             symbol_values, pauli_sums, grad)
 

--- a/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
@@ -47,271 +47,284 @@ def _gen_single_bit_rotation_problem(bit, symbols, noisy):
     return circuit
 
 
-# class ExpectationTest(tf.test.TestCase):
-#     """Basic tests for the expectation layer."""
+class ExpectationTest(tf.test.TestCase):
+    """Basic tests for the expectation layer."""
 
-#     def test_expectation_instantiate(self):
-#         """Test that Expectation instantiates correctly."""
-#         expectation.Expectation()
-#         expectation.Expectation(backend=None)
-#         expectation.Expectation(backend='noisy')
-#         expectation.Expectation(backend='noiseless')
-#         expectation.Expectation(backend=cirq.Simulator())
-#         expectation.Expectation(
-#             differentiator=linear_combination.ForwardDifference())
+    def test_expectation_instantiate(self):
+        """Test that Expectation instantiates correctly."""
+        expectation.Expectation()
+        expectation.Expectation(backend=None)
+        expectation.Expectation(backend='noisy')
+        expectation.Expectation(backend='noiseless')
+        expectation.Expectation(backend=cirq.Simulator())
+        expectation.Expectation(
+            differentiator=linear_combination.ForwardDifference())
 
-#     def test_expectation_instantiate_error(self):
-#         """Test that Expectation errors with bad inputs."""
+    def test_expectation_instantiate_error(self):
+        """Test that Expectation errors with bad inputs."""
 
-#         class MySampler(cirq.Sampler):
-#             """Class to test sampler detection in Expectation."""
+        class MySampler(cirq.Sampler):
+            """Class to test sampler detection in Expectation."""
 
-#             def run_sweep(self):
-#                 """do nothing."""
-#                 return
+            def run_sweep(self):
+                """do nothing."""
+                return
 
-#         with self.assertRaisesRegex(TypeError,
-#                                     expected_regex="SampledExpectation"):
-#             expectation.Expectation(backend=MySampler())
+        with self.assertRaisesRegex(TypeError,
+                                    expected_regex="SampledExpectation"):
+            expectation.Expectation(backend=MySampler())
 
-#         with self.assertRaisesRegex(
-#                 TypeError, expected_regex="SimulatesExpectationValues or None"):
-#             expectation.Expectation(backend='junk')
+        with self.assertRaisesRegex(
+                TypeError,
+                expected_regex="SimulatesExpectationValues or None",
+        ):
+            expectation.Expectation(backend='junk')
 
-#         with self.assertRaisesRegex(
-#                 TypeError, expected_regex="tfq.differentiators.Differentiator"):
-#             expectation.Expectation(differentiator='junk')
+        with self.assertRaisesRegex(
+                TypeError,
+                expected_regex="tfq.differentiators.Differentiator",
+        ):
+            expectation.Expectation(differentiator='junk')
 
-#     def test_expectation_type_inputs_error(self):
-#         """Test that expectation errors within Keras call."""
+    def test_expectation_type_inputs_error(self):
+        """Test that expectation errors within Keras call."""
 
-#         bit = cirq.GridQubit(0, 0)
-#         test_pstring = cirq.Z(bit)
-#         test_psum = cirq.PauliSum.from_pauli_strings([test_pstring])
-#         reg_circuit = cirq.Circuit(cirq.H(bit))
+        bit = cirq.GridQubit(0, 0)
+        test_pstring = cirq.Z(bit)
+        test_psum = cirq.PauliSum.from_pauli_strings([test_pstring])
+        reg_circuit = cirq.Circuit(cirq.H(bit))
 
-#         with self.assertRaisesRegex(Exception,
-#                                     expected_regex="Unknown initializer"):
-#             expectation.Expectation()(reg_circuit,
-#                                       operators=test_psum,
-#                                       initializer='junk')
+        with self.assertRaisesRegex(Exception,
+                                    expected_regex="Unknown initializer"):
+            expectation.Expectation()(reg_circuit,
+                                      operators=test_psum,
+                                      initializer='junk')
 
-#         with self.assertRaisesRegex(Exception,
-#                                     expected_regex="repetitions not provided"):
-#             expectation.Expectation(backend='noisy')(reg_circuit,
-#                                                      operators=test_psum)
+        with self.assertRaisesRegex(Exception,
+                                    expected_regex="repetitions not provided"):
+            expectation.Expectation(backend='noisy')(reg_circuit,
+                                                     operators=test_psum)
 
-#         with self.assertRaisesRegex(Exception,
-#                                     expected_regex="cannot be parsed"):
-#             expectation.Expectation(backend='noisy')(reg_circuit,
-#                                                      operators=test_psum,
-#                                                      repetitions='junk')
+        with self.assertRaisesRegex(Exception,
+                                    expected_regex="cannot be parsed"):
+            expectation.Expectation(backend='noisy')(reg_circuit,
+                                                     operators=test_psum,
+                                                     repetitions='junk')
 
-#         with self.assertRaisesRegex(Exception, expected_regex="noiseless"):
-#             expectation.Expectation(backend='noiseless')(reg_circuit,
-#                                                          operators=test_psum,
-#                                                          repetitions=1)
+        with self.assertRaisesRegex(Exception, expected_regex="noiseless"):
+            expectation.Expectation(backend='noiseless')(reg_circuit,
+                                                         operators=test_psum,
+                                                         repetitions=1)
 
-#     def test_expectation_op_error(self):
-#         """Test that expectation errors within underlying ops correctly."""
+    def test_expectation_op_error(self):
+        """Test that expectation errors within underlying ops correctly."""
 
-#         bit = cirq.GridQubit(0, 0)
-#         symbol = sympy.Symbol('alpha')
-#         test_pstring = cirq.Z(bit)
-#         test_psum = cirq.PauliSum.from_pauli_strings([test_pstring])
-#         symb_circuit = cirq.Circuit(cirq.H(bit)**symbol)
-#         reg_circuit = cirq.Circuit(cirq.H(bit))
+        bit = cirq.GridQubit(0, 0)
+        symbol = sympy.Symbol('alpha')
+        test_pstring = cirq.Z(bit)
+        test_psum = cirq.PauliSum.from_pauli_strings([test_pstring])
+        symb_circuit = cirq.Circuit(cirq.H(bit)**symbol)
+        reg_circuit = cirq.Circuit(cirq.H(bit))
 
-#         with self.assertRaisesRegex(Exception,
-#                                     expected_regex="Could not find symbol"):
-#             # No symbol matchups.
-#             expectation.Expectation()([symb_circuit], operators=test_psum)
+        with self.assertRaisesRegex(Exception,
+                                    expected_regex="Could not find symbol"):
+            # No symbol matchups.
+            expectation.Expectation()([symb_circuit], operators=test_psum)
 
-#         with self.assertRaisesRegex(Exception,
-#                                     expected_regex="Unparseable proto"):
-#             # Proto is unparseable.
-#             expectation.Expectation()([reg_circuit],
-#                                       operators=tf.convert_to_tensor(
-#                                           [['bad_operator']]))
+        with self.assertRaisesRegex(Exception,
+                                    expected_regex="Unparseable proto"):
+            # Proto is unparseable.
+            expectation.Expectation()([reg_circuit],
+                                      operators=tf.convert_to_tensor(
+                                          [['bad_operator']]))
 
-#         with self.assertRaisesRegex(Exception, expected_regex="rank 2"):
-#             # Operators has wrong rank.
-#             expectation.Expectation()([reg_circuit],
-#                                       operators=util.convert_to_tensor(
-#                                           [test_psum]))
+        with self.assertRaisesRegex(Exception, expected_regex="rank 2"):
+            # Operators has wrong rank.
+            expectation.Expectation()([reg_circuit],
+                                      operators=util.convert_to_tensor(
+                                          [test_psum]))
 
-#         with self.assertRaisesRegex(Exception, expected_regex="rank 2"):
-#             # symbol_values has wrong rank.
-#             expectation.Expectation()([symb_circuit],
-#                                       symbol_names=[symbol],
-#                                       symbol_values=[0.5],
-#                                       operators=test_psum)
+        with self.assertRaisesRegex(Exception, expected_regex="rank 2"):
+            # symbol_values has wrong rank.
+            expectation.Expectation()([symb_circuit],
+                                      symbol_names=[symbol],
+                                      symbol_values=[0.5],
+                                      operators=test_psum)
 
-#         with self.assertRaisesRegex(Exception, expected_regex="do not match."):
-#             # Wrong batch size for pauli operators.
-#             expectation.Expectation()(symb_circuit,
-#                                       symbol_names=[symbol],
-#                                       operators=[[test_psum], [test_psum]])
+        with self.assertRaisesRegex(Exception, expected_regex="do not match."):
+            # Wrong batch size for pauli operators.
+            expectation.Expectation()(symb_circuit,
+                                      symbol_names=[symbol],
+                                      operators=[[test_psum], [test_psum]])
 
-#         with self.assertRaisesRegex(Exception, expected_regex="do not match."):
-#             # Wrong batch_size for symbol values.
-#             expectation.Expectation()([symb_circuit],
-#                                       symbol_names=[symbol],
-#                                       symbol_values=np.zeros((3, 1)),
-#                                       operators=test_psum)
+        with self.assertRaisesRegex(Exception, expected_regex="do not match."):
+            # Wrong batch_size for symbol values.
+            expectation.Expectation()([symb_circuit],
+                                      symbol_names=[symbol],
+                                      symbol_values=np.zeros((3, 1)),
+                                      operators=test_psum)
 
-#     def test_static_cases(self):
-#         """Run inputs through in complex cases."""
+    def test_static_cases(self):
+        """Run inputs through in complex cases."""
 
-#         bit = cirq.GridQubit(0, 0)
-#         symbol = sympy.Symbol('alpha')
-#         test_pstring = cirq.Z(bit)
-#         test_psum = cirq.PauliSum.from_pauli_strings([test_pstring])
-#         symb_circuit = cirq.Circuit(cirq.H(bit)**symbol)
-#         reg_circuit = cirq.Circuit(cirq.H(bit))
+        bit = cirq.GridQubit(0, 0)
+        symbol = sympy.Symbol('alpha')
+        test_pstring = cirq.Z(bit)
+        test_psum = cirq.PauliSum.from_pauli_strings([test_pstring])
+        symb_circuit = cirq.Circuit(cirq.H(bit)**symbol)
+        reg_circuit = cirq.Circuit(cirq.H(bit))
 
-#         # Passing a 2d operators input requires a 1d circuit input.
-#         expectation.Expectation()([reg_circuit, reg_circuit],
-#                                   operators=[[test_psum, test_psum],
-#                                              [test_psum, test_psum]])
+        # Passing a 2d operators input requires a 1d circuit input.
+        expectation.Expectation()([reg_circuit, reg_circuit],
+                                  operators=[[test_psum, test_psum],
+                                             [test_psum, test_psum]])
 
-#         # Passing 2d operators along with other inputs.
-#         expectation.Expectation()([symb_circuit, symb_circuit],
-#                                   symbol_names=[symbol],
-#                                   operators=[[test_psum, test_psum],
-#                                              [test_psum, test_psum]])
-#         expectation.Expectation()([symb_circuit, symb_circuit],
-#                                   symbol_names=[symbol],
-#                                   symbol_values=[[0.5], [0.8]],
-#                                   operators=[[test_psum, test_psum],
-#                                              [test_psum, test_psum]])
+        # Passing 2d operators along with other inputs.
+        expectation.Expectation()([symb_circuit, symb_circuit],
+                                  symbol_names=[symbol],
+                                  operators=[[test_psum, test_psum],
+                                             [test_psum, test_psum]])
+        expectation.Expectation()([symb_circuit, symb_circuit],
+                                  symbol_names=[symbol],
+                                  symbol_values=[[0.5], [0.8]],
+                                  operators=[[test_psum, test_psum],
+                                             [test_psum, test_psum]])
 
-#         # Ensure tiling up of circuits works as expected.
-#         expectation.Expectation()(reg_circuit, operators=test_psum)
-#         expectation.Expectation()(reg_circuit, operators=[test_psum, test_psum])
+        # Ensure tiling up of circuits works as expected.
+        expectation.Expectation()(reg_circuit, operators=test_psum)
+        expectation.Expectation()(
+            reg_circuit,
+            operators=[test_psum, test_psum],
+        )
 
-#         # Ensure tiling up of symbol_values works as expected.
-#         expectation.Expectation()(symb_circuit,
-#                                   symbol_names=[symbol],
-#                                   symbol_values=[[0.5], [0.8]],
-#                                   operators=test_psum)
-#         expectation.Expectation()(symb_circuit,
-#                                   symbol_names=[symbol],
-#                                   symbol_values=[[0.5]],
-#                                   operators=test_psum)
+        # Ensure tiling up of symbol_values works as expected.
+        expectation.Expectation()(symb_circuit,
+                                  symbol_names=[symbol],
+                                  symbol_values=[[0.5], [0.8]],
+                                  operators=test_psum)
+        expectation.Expectation()(symb_circuit,
+                                  symbol_names=[symbol],
+                                  symbol_values=[[0.5]],
+                                  operators=test_psum)
 
-#     def test_static_cases_noisy(self):
-#         """Test that the noisy trajectory backend works in complex cases."""
-#         bit = cirq.GridQubit(0, 0)
-#         symbol = sympy.Symbol('alpha')
-#         test_pstring = cirq.Z(bit)
-#         test_psum = cirq.PauliSum.from_pauli_strings([test_pstring])
-#         symb_circuit = cirq.Circuit(cirq.H(bit)**symbol)
-#         reg_circuit = cirq.Circuit(cirq.H(bit))
+    def test_static_cases_noisy(self):
+        """Test that the noisy trajectory backend works in complex cases."""
+        bit = cirq.GridQubit(0, 0)
+        symbol = sympy.Symbol('alpha')
+        test_pstring = cirq.Z(bit)
+        test_psum = cirq.PauliSum.from_pauli_strings([test_pstring])
+        symb_circuit = cirq.Circuit(cirq.H(bit)**symbol)
+        reg_circuit = cirq.Circuit(cirq.H(bit))
 
-#         # Passing a 2d operators input requires a 1d circuit input.
-#         expectation.Expectation(backend='noisy')(
-#             [reg_circuit, reg_circuit],
-#             operators=[[test_psum, test_psum], [test_psum, test_psum]],
-#             repetitions=1)
+        # Passing a 2d operators input requires a 1d circuit input.
+        expectation.Expectation(backend='noisy')(
+            [reg_circuit, reg_circuit],
+            operators=[[test_psum, test_psum], [test_psum, test_psum]],
+            repetitions=1)
 
-#         # Passing 2d operators along with other inputs.
-#         expectation.Expectation(backend='noisy')(
-#             [symb_circuit, symb_circuit],
-#             symbol_names=[symbol],
-#             operators=[[test_psum, test_psum], [test_psum, test_psum]],
-#             repetitions=1)
-#         expectation.Expectation(backend='noisy')(
-#             [symb_circuit, symb_circuit],
-#             symbol_names=[symbol],
-#             symbol_values=[[0.5], [0.8]],
-#             operators=[[test_psum, test_psum], [test_psum, test_psum]],
-#             repetitions=1)
+        # Passing 2d operators along with other inputs.
+        expectation.Expectation(backend='noisy')(
+            [symb_circuit, symb_circuit],
+            symbol_names=[symbol],
+            operators=[[test_psum, test_psum], [test_psum, test_psum]],
+            repetitions=1)
+        expectation.Expectation(backend='noisy')(
+            [symb_circuit, symb_circuit],
+            symbol_names=[symbol],
+            symbol_values=[[0.5], [0.8]],
+            operators=[[test_psum, test_psum], [test_psum, test_psum]],
+            repetitions=1)
 
-#         # Ensure tiling up of circuits works as expected.
-#         expectation.Expectation(backend='noisy')(reg_circuit,
-#                                                  operators=test_psum,
-#                                                  repetitions=1)
-#         expectation.Expectation(backend='noisy')(
-#             reg_circuit, operators=[test_psum, test_psum], repetitions=1)
+        # Ensure tiling up of circuits works as expected.
+        expectation.Expectation(backend='noisy')(reg_circuit,
+                                                 operators=test_psum,
+                                                 repetitions=1)
+        expectation.Expectation(backend='noisy')(
+            reg_circuit, operators=[test_psum, test_psum], repetitions=1)
 
-#         # Ensure tiling up of symbol_values works as expected.
-#         expectation.Expectation(backend='noisy')(symb_circuit,
-#                                                  symbol_names=[symbol],
-#                                                  symbol_values=[[0.5], [0.8]],
-#                                                  operators=test_psum,
-#                                                  repetitions=1)
-#         expectation.Expectation(backend='noisy')(symb_circuit,
-#                                                  symbol_names=[symbol],
-#                                                  symbol_values=[[0.5]],
-#                                                  operators=test_psum,
-#                                                  repetitions=1)
+        # Ensure tiling up of symbol_values works as expected.
+        expectation.Expectation(backend='noisy')(symb_circuit,
+                                                 symbol_names=[symbol],
+                                                 symbol_values=[[0.5], [0.8]],
+                                                 operators=test_psum,
+                                                 repetitions=1)
+        expectation.Expectation(backend='noisy')(symb_circuit,
+                                                 symbol_names=[symbol],
+                                                 symbol_values=[[0.5]],
+                                                 operators=test_psum,
+                                                 repetitions=1)
 
-#         # Test multiple operators with integer valued repetition.
-#         expectation.Expectation(backend='noisy')(
-#             symb_circuit,
-#             symbol_names=[symbol],
-#             symbol_values=[[0.5]],
-#             operators=[-1.0 * cirq.Z(bit),
-#                        cirq.X(bit) + 2.0 * cirq.Z(bit)],
-#             repetitions=1)
-#         expectation.Expectation(backend='noisy')(
-#             symb_circuit,
-#             symbol_names=[symbol],
-#             symbol_values=[[0.5]],
-#             operators=[-1.0 * cirq.Z(bit),
-#                        cirq.X(bit) + 2.0 * cirq.Z(bit)],
-#             repetitions=[5, 1])
+        # Test multiple operators with integer valued repetition.
+        expectation.Expectation(backend='noisy')(
+            symb_circuit,
+            symbol_names=[symbol],
+            symbol_values=[[0.5]],
+            operators=[-1.0 * cirq.Z(bit),
+                       cirq.X(bit) + 2.0 * cirq.Z(bit)],
+            repetitions=1)
+        expectation.Expectation(backend='noisy')(
+            symb_circuit,
+            symbol_names=[symbol],
+            symbol_values=[[0.5]],
+            operators=[-1.0 * cirq.Z(bit),
+                       cirq.X(bit) + 2.0 * cirq.Z(bit)],
+            repetitions=[5, 1])
 
-#         # Test 2d repetitions.
-#         expectation.Expectation(backend='noisy')(
-#             [symb_circuit, symb_circuit],
-#             symbol_names=[symbol],
-#             symbol_values=[[0.5], [0.4]],
-#             operators=[[
-#                 -1.0 * cirq.Z(bit),
-#                 cirq.X(bit) + 2.0 * cirq.Z(bit),
-#                 cirq.Z(bit)
-#             ], [cirq.Z(bit), cirq.Z(bit), cirq.Z(bit)]],
-#             repetitions=[[1, 2, 3], [4, 5, 6]])
+        # Test 2d repetitions.
+        expectation.Expectation(backend='noisy')(
+            [symb_circuit, symb_circuit],
+            symbol_names=[symbol],
+            symbol_values=[[0.5], [0.4]],
+            operators=[[
+                -1.0 * cirq.Z(bit),
+                cirq.X(bit) + 2.0 * cirq.Z(bit),
+                cirq.Z(bit)
+            ], [cirq.Z(bit), cirq.Z(bit), cirq.Z(bit)]],
+            repetitions=[[1, 2, 3], [4, 5, 6]])
 
-#     def test_expectation_simple_tf_train(self):
-#         """Train a layer using standard tf (not keras).
-#         This is a subtle test that will work since we don't use keras compile.
-#         """
-#         bit = cirq.GridQubit(0, 0)
-#         circuit = \
-#             cirq.Circuit(cirq.rx(sympy.Symbol('theta'))(bit))
-#         op = cirq.Z(bit)
-#         layer = expectation.Expectation()
-#         optimizer = tf.optimizers.Adam(learning_rate=0.05)
-#         for _ in range(200):
-#             with tf.GradientTape() as tape:
-#                 circuit_out = layer(circuit,
-#                                     symbol_names=['theta'],
-#                                     operators=op)
-#                 mse = tf.square(tf.reduce_sum(tf.subtract(circuit_out, -1)))
-#             grads = tape.gradient(mse, layer.trainable_weights)
-#             optimizer.apply_gradients(zip(grads, layer.trainable_weights))
-#         self.assertAllClose(mse.numpy(), 0, atol=1e-3)
+    def test_expectation_simple_tf_train(self):
+        """Train a layer using standard tf (not keras).
+        This is a subtle test that will work since we don't use keras compile.
+        """
+        bit = cirq.GridQubit(0, 0)
+        circuit = \
+            cirq.Circuit(cirq.rx(sympy.Symbol('theta'))(bit))
+        op = cirq.Z(bit)
+        layer = expectation.Expectation()
+        optimizer = tf.optimizers.Adam(learning_rate=0.05)
+        for _ in range(200):
+            with tf.GradientTape() as tape:
+                circuit_out = layer(circuit,
+                                    symbol_names=['theta'],
+                                    operators=op)
+                mse = tf.square(tf.reduce_sum(tf.subtract(circuit_out, -1)))
+            grads = tape.gradient(mse, layer.trainable_weights)
+            optimizer.apply_gradients(zip(grads, layer.trainable_weights))
+        self.assertAllClose(mse.numpy(), 0, atol=1e-3)
 
 
 class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
     """Test hybrid/integrated models that include an expectation layer."""
 
     @parameterized.parameters([
-        # {
-        #     'backend': 'noisy'
-        # },
         {
-            'backend': None  # old API usage
+            'backend': 'noisy',
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,  # old API usage
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,
+            'use_cuquantum': True,
         }
     ])
-    def test_simple_param_value_input(self, backend):
+    def test_simple_param_value_input(self, backend, use_cuquantum):
         """Train a densely connected hybrid model.
 
-        This model will put a qubit in the zero or one state from a random state
-        given the input zero or one. This tests the input signature:
+        This model will put a qubit in the zero or one state from a random
+        state given the input zero or one. This tests the input signature:
         Expectation([input_value_batch]).
         """
         noisy = backend == 'noisy'
@@ -324,12 +337,14 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         l1 = tf.keras.layers.Dense(10)(inputs)
         l2 = tf.keras.layers.Dense(3)(l1)
         reps = 1000 if noisy else None
-        outputs = expectation.Expectation(backend=backend, use_cuquantum=True)(
-            datum,
-            symbol_names=symbols,
-            operators=cirq.Z(bit),
-            symbol_values=l2,
-            repetitions=reps)
+        outputs = expectation.Expectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(datum,
+          symbol_names=symbols,
+          operators=cirq.Z(bit),
+          symbol_values=l2,
+          repetitions=reps)
         model = tf.keras.Model(inputs=[datum, inputs], outputs=outputs)
 
         data_in = np.array([[1], [0]], dtype=np.float32)
@@ -344,153 +359,181 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         tol = 5e-2 if noisy else 1e-3
         self.assertAllClose(history.history['loss'][-1], 0, atol=tol)
 
-    # @parameterized.parameters([
-    #     {
-    #         'backend': 'noisy'
-    #     },
-    #     {
-    #         'backend': None  # old API usage
-    #     }
-    # ])
-    # def test_simple_op_input(self, backend):
-    #     """Test a simple operator input
+    @parameterized.parameters([
+        {
+            'backend': 'noisy',
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,  # old API usage
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,
+            'use_cuquantum': True,
+        }
+    ])
+    def test_simple_op_input(self, backend, use_cuquantum):
+        """Test a simple operator input
 
-    #     Learn qubit in the z+ state using two different measurement operators.
-    #     This tests input signature Expectation([operator_batch])
-    #     """
-    #     noisy = backend == 'noisy'
-    #     bit = cirq.GridQubit(0, 0)
-    #     symbols = sympy.symbols('x, y, z')
+        Learn qubit in the z+ state using two different measurement operators.
+        This tests input signature Expectation([operator_batch])
+        """
+        noisy = backend == 'noisy'
+        bit = cirq.GridQubit(0, 0)
+        symbols = sympy.symbols('x, y, z')
 
-    #     circuits = util.convert_to_tensor(
-    #         [_gen_single_bit_rotation_problem(bit, symbols, noisy)] * 2)
+        circuits = util.convert_to_tensor(
+            [_gen_single_bit_rotation_problem(bit, symbols, noisy)] * 2)
 
-    #     data_out = tf.convert_to_tensor(np.array([[1], [1]]))
-    #     ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.Z(bit)]])
+        data_out = tf.convert_to_tensor(np.array([[1], [1]]))
+        ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.Z(bit)]])
 
-    #     circuit_input = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
-    #     op_input = tf.keras.Input(shape=(1,), dtype=tf.dtypes.string)
+        circuit_input = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
+        op_input = tf.keras.Input(shape=(1,), dtype=tf.dtypes.string)
 
-    #     reps = 1000 if noisy else None
-    #     output = expectation.Expectation(backend=backend)(
-    #         circuit_input,
-    #         symbol_names=symbols,
-    #         operators=op_input,
-    #         initializer=tf.keras.initializers.RandomNormal(),
-    #         repetitions=reps)
+        reps = 1000 if noisy else None
+        output = expectation.Expectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(circuit_input,
+          symbol_names=symbols,
+          operators=op_input,
+          initializer=tf.keras.initializers.RandomNormal(),
+          repetitions=reps)
 
-    #     model = tf.keras.Model(inputs=[circuit_input, op_input], outputs=output)
+        model = tf.keras.Model(
+            inputs=[circuit_input, op_input],
+            outputs=output,
+        )
 
-    #     model.compile(
-    #         optimizer=tf.keras.optimizers.Adam(learning_rate=0.05),
-    #         loss=tf.keras.losses.mean_squared_error,
-    #     )
-    #     history = model.fit(x=[circuits, ops],
-    #                         y=data_out,
-    #                         batch_size=2,
-    #                         epochs=200)
-    #     tol = 5e-2 if noisy else 1e-3
-    #     self.assertAllClose(history.history['loss'][-1], 0, atol=tol)
+        model.compile(
+            optimizer=tf.keras.optimizers.Adam(learning_rate=0.05),
+            loss=tf.keras.losses.mean_squared_error,
+        )
+        history = model.fit(x=[circuits, ops],
+                            y=data_out,
+                            batch_size=2,
+                            epochs=200)
+        tol = 5e-2 if noisy else 1e-3
+        self.assertAllClose(history.history['loss'][-1], 0, atol=tol)
 
-    # @parameterized.parameters([
-    #     {
-    #         'backend': 'noisy'
-    #     },
-    #     {
-    #         'backend': None  # old api usage.
-    #     },
-    #     {
-    #         'backend': cirq.Simulator()
-    #     }
-    # ])
-    # def test_simple_op_and_param_input(self, backend):
-    #     """Test a simple operator and parameter input.
+    @parameterized.parameters([
+        {
+            'backend': 'noisy',
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,  # old api usage.
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,
+            'use_cuquantum': True,
+        },
+        {
+            'backend': cirq.Simulator(),
+            'use_cuquantum': False,
+        }
+    ])
+    def test_simple_op_and_param_input(self, backend, use_cuquantum):
+        """Test a simple operator and parameter input.
 
-    #     Train a NN to put a qubit in the z+ or x+ states based on a classical
-    #     binary input. This tests the input signature:
-    #     Expectation([value_batch, operator_batch]).
-    #     """
-    #     noisy = backend == 'noisy'
-    #     bit = cirq.GridQubit(0, 0)
-    #     symbols = sympy.symbols('x, y, z')
-    #     ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.X(bit)]])
-    #     circuits = util.convert_to_tensor(
-    #         [_gen_single_bit_rotation_problem(bit, symbols, noisy)] * 2)
-    #     data_in = np.array([[1], [0]])
-    #     data_out = np.array([[1], [1]])
+        Train a NN to put a qubit in the z+ or x+ states based on a classical
+        binary input. This tests the input signature:
+        Expectation([value_batch, operator_batch]).
+        """
+        noisy = backend == 'noisy'
+        bit = cirq.GridQubit(0, 0)
+        symbols = sympy.symbols('x, y, z')
+        ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.X(bit)]])
+        circuits = util.convert_to_tensor(
+            [_gen_single_bit_rotation_problem(bit, symbols, noisy)] * 2)
+        data_in = np.array([[1], [0]])
+        data_out = np.array([[1], [1]])
 
-    #     data_inp = tf.keras.Input(shape=(1), dtype=tf.dtypes.float32)
-    #     op_inp = tf.keras.Input(shape=(1,), dtype=tf.dtypes.string)
-    #     circuit_inp = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
-    #     dense_1 = tf.keras.layers.Dense(10)(data_inp)
-    #     dense_2 = tf.keras.layers.Dense(3)(dense_1)
-    #     reps = 1000 if noisy else None
-    #     circuit_output = expectation.Expectation(backend=backend)(
-    #         circuit_inp,
-    #         symbol_names=symbols,
-    #         symbol_values=dense_2,
-    #         operators=op_inp,
-    #         repetitions=reps)
+        data_inp = tf.keras.Input(shape=(1), dtype=tf.dtypes.float32)
+        op_inp = tf.keras.Input(shape=(1,), dtype=tf.dtypes.string)
+        circuit_inp = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
+        dense_1 = tf.keras.layers.Dense(10)(data_inp)
+        dense_2 = tf.keras.layers.Dense(3)(dense_1)
+        reps = 1000 if noisy else None
+        circuit_output = expectation.Expectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(circuit_inp,
+          symbol_names=symbols,
+          symbol_values=dense_2,
+          operators=op_inp,
+          repetitions=reps)
 
-    #     functional_model = tf.keras.Model(
-    #         inputs=[data_inp, op_inp, circuit_inp], outputs=[circuit_output])
+        functional_model = tf.keras.Model(
+            inputs=[data_inp, op_inp, circuit_inp], outputs=[circuit_output])
 
-    #     functional_model.compile(
-    #         optimizer=tf.keras.optimizers.Adam(learning_rate=0.05),
-    #         loss=tf.keras.losses.mean_squared_error)
-    #     history = functional_model.fit(x=[data_in, ops, circuits],
-    #                                    y=data_out,
-    #                                    batch_size=2,
-    #                                    epochs=100)
-    #     tol = 5e-2 if noisy else 1e-3
-    #     self.assertAllClose(history.history['loss'][-1], 0, atol=tol)
+        functional_model.compile(
+            optimizer=tf.keras.optimizers.Adam(learning_rate=0.05),
+            loss=tf.keras.losses.mean_squared_error)
+        history = functional_model.fit(x=[data_in, ops, circuits],
+                                       y=data_out,
+                                       batch_size=2,
+                                       epochs=100)
+        tol = 5e-2 if noisy else 1e-3
+        self.assertAllClose(history.history['loss'][-1], 0, atol=tol)
 
-    # @parameterized.parameters([
-    #     {
-    #         'backend': 'noisy'
-    #     },
-    #     {
-    #         'backend': None  # old api usage.
-    #     }
-    # ])
-    # def test_dnn_qnn_dnn(self, backend):
-    #     """Train a fully hybrid network using an Expectation layer.
+    @parameterized.parameters([
+        {
+            'backend': 'noisy',
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,  # old API usage
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,
+            'use_cuquantum': True,
+        }
+    ])
+    def test_dnn_qnn_dnn(self, backend, use_cuquantum):
+        """Train a fully hybrid network using an Expectation layer.
 
-    #     Train the network to output +-5 given an input of 1 or 0. This tests
-    #     that everything works when Expectation layer is a middle layers.
-    #     """
-    #     noisy = backend == 'noisy'
-    #     bit = cirq.GridQubit(0, 0)
-    #     symbols = sympy.symbols('x, y, z')
-    #     circuits = util.convert_to_tensor(
-    #         [_gen_single_bit_rotation_problem(bit, symbols, noisy)] * 2)
-    #     data_in = np.array([[1], [0]], dtype=np.float32)
-    #     data_out = np.array([[5], [-5]], dtype=np.float32)
+        Train the network to output +-5 given an input of 1 or 0. This tests
+        that everything works when Expectation layer is a middle layers.
+        """
+        noisy = backend == 'noisy'
+        bit = cirq.GridQubit(0, 0)
+        symbols = sympy.symbols('x, y, z')
+        circuits = util.convert_to_tensor(
+            [_gen_single_bit_rotation_problem(bit, symbols, noisy)] * 2)
+        data_in = np.array([[1], [0]], dtype=np.float32)
+        data_out = np.array([[5], [-5]], dtype=np.float32)
 
-    #     classical_input = tf.keras.Input(shape=(1,))
-    #     circuit_input = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
-    #     d1 = tf.keras.layers.Dense(10)(classical_input)
-    #     d2 = tf.keras.layers.Dense(3)(d1)
-    #     reps = 1000 if noisy else None
-    #     quantum = expectation.Expectation(backend=backend)(
-    #         circuit_input,
-    #         symbol_names=symbols,
-    #         symbol_values=d2,
-    #         operators=cirq.Z(bit),
-    #         repetitions=reps)
-    #     d3 = tf.keras.layers.Dense(1)(quantum)
+        classical_input = tf.keras.Input(shape=(1,))
+        circuit_input = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
+        d1 = tf.keras.layers.Dense(10)(classical_input)
+        d2 = tf.keras.layers.Dense(3)(d1)
+        reps = 1000 if noisy else None
+        quantum = expectation.Expectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(circuit_input,
+          symbol_names=symbols,
+          symbol_values=d2,
+          operators=cirq.Z(bit),
+          repetitions=reps)
+        d3 = tf.keras.layers.Dense(1)(quantum)
 
-    #     model = tf.keras.Model(inputs=[circuit_input, classical_input],
-    #                            outputs=d3)
+        model = tf.keras.Model(inputs=[circuit_input, classical_input],
+                               outputs=d3)
 
-    #     model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=0.05),
-    #                   loss=tf.keras.losses.mean_squared_error)
-    #     history = model.fit(x=[circuits, data_in],
-    #                         y=data_out,
-    #                         batch_size=2,
-    #                         epochs=300)
-    #     tol = 5e-2 if noisy else 1e-3
-    #     self.assertAllClose(history.history['loss'][-1], 0, atol=tol)
+        model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=0.05),
+                      loss=tf.keras.losses.mean_squared_error)
+        history = model.fit(x=[circuits, data_in],
+                            y=data_out,
+                            batch_size=2,
+                            epochs=300)
+        tol = 5e-2 if noisy else 1e-3
+        self.assertAllClose(history.history['loss'][-1], 0, atol=tol)
 
 
 if __name__ == '__main__':

--- a/tensorflow_quantum/python/layers/circuit_executors/sample.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample.py
@@ -155,11 +155,11 @@ class Sample(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         used_op = None
         if backend == 'noiseless':
-            used_op = circuit_execution_ops.get_sampling_op(None, \
-                                                            use_cuquantum=use_cuquantum)
+            used_op = circuit_execution_ops.get_sampling_op(
+                None, use_cuquantum=use_cuquantum)
         elif backend == 'noisy':
             if use_cuquantum:
-                raise ValueError('noisy backend does not currently support GPU')
+                raise ValueError('noisy backend has no GPU support.')
             used_op = noisy_samples_op.samples
         else:
             used_op = circuit_execution_ops.get_sampling_op(backend)

--- a/tensorflow_quantum/python/layers/circuit_executors/sample.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample.py
@@ -19,6 +19,7 @@ import tensorflow as tf
 
 from tensorflow_quantum.core.ops import circuit_execution_ops
 from tensorflow_quantum.core.ops.noise import noisy_samples_op
+from tensorflow_quantum.python import quantum_context
 from tensorflow_quantum.python.layers.circuit_executors import input_checks
 
 
@@ -154,9 +155,13 @@ class Sample(tf.keras.layers.Layer):
         """
         super().__init__(**kwargs)
         used_op = None
-        if backend == 'noiseless':
+        if backend == 'noiseless' or backend is None:
+            mode = quantum_context.get_quantum_concurrent_op_mode()
+            quantum_concurrent = False if use_cuquantum else mode
             used_op = circuit_execution_ops.get_sampling_op(
-                None, use_cuquantum=use_cuquantum)
+                None,
+                use_cuquantum=use_cuquantum,
+                quantum_concurrent=quantum_concurrent)
         elif backend == 'noisy':
             if use_cuquantum:
                 raise ValueError('noisy backend has no GPU support.')

--- a/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
@@ -162,7 +162,7 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
         output = sampler([circuit, circuit], repetitions=5)
         self.assertShapeEqual(np.empty((2, 5, 1)), output.to_tensor())
 
-    # TODO(trevormccrt): add QuantumEngineSampler to this once it is available
+    # TODO(trevormccrt): add ProcessorSampler to this once it is available
     @parameterized.parameters(
         list(
             util.kwargs_cartesian_product(

--- a/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
@@ -85,21 +85,29 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters([
         {
-            'backend': 'noiseless'
+            'backend': 'noiseless',
+            'use_cuquantum': False,
         },
         {
-            'backend': 'noisy'
+            'backend': 'noisy',
+            'use_cuquantum': False,
         },
         {
-            'backend': cirq.Simulator()
+            'backend': cirq.Simulator(),
+            'use_cuquantum': False,
         },
         {
-            'backend': None  # old API usage.
+            'backend': None,  # old API usage.
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,
+            'use_cuquantum': True,
         }
     ])
-    def test_sample_invalid_combinations(self, backend):
+    def test_sample_invalid_combinations(self, backend, use_cuquantum):
         """Test with valid type inputs and valid value, but incorrect combo."""
-        sampler = sample.Sample(backend)
+        sampler = sample.Sample(backend, use_cuquantum=use_cuquantum)
         symbol = sympy.Symbol('alpha')
         circuit = cirq.Circuit(cirq.H(cirq.GridQubit(0, 0))**symbol)
         with self.assertRaisesRegex(Exception, expected_regex=""):
@@ -168,18 +176,24 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
             util.kwargs_cartesian_product(
                 backend=['noiseless', 'noisy',
                          cirq.Simulator(), None],
+                use_cuquantum=[False, True],
                 all_n_qubits=[[3, 4, 10]],
                 n_samples=[1],
                 symbol_names=[[], ['a', 'b']])))
-    def test_sample_output(self, backend, all_n_qubits, n_samples,
-                           symbol_names):
+    def test_sample_output(self, backend, use_cuquantum, all_n_qubits,
+                           n_samples, symbol_names):
         """Test that expected output format is preserved.
 
         Check that any pre or post processing done inside the layers does not
         cause what is output from the layer to structurally deviate from what
         is expected.
         """
-        sampler = sample.Sample(backend=backend)
+        if use_cuquantum:
+            # If use_cuquantum is True,
+            if backend is not None and backend != 'noiseless':
+                return
+            # Passes backend=None or backend == 'noiseless' only.
+        sampler = sample.Sample(backend=backend, use_cuquantum=use_cuquantum)
         bits = cirq.GridQubit.rect(1, max(all_n_qubits))
         programs = []
         expected_outputs = []

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
@@ -97,22 +97,36 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
 
     @parameterized.parameters([
         {
-            'backend': 'noisy'
+            'backend': 'noisy',
+            'use_cuquantum': False,
         },
         {
-            'backend': 'noiseless'
+            'backend': 'noiseless',
+            'use_cuquantum': False,
         },
         {
-            'backend': cirq.Simulator()
+            'backend': 'noiseless',
+            'use_cuquantum': True,
         },
         {
-            'backend': CustomSampler()
+            'backend': cirq.Simulator(),
+            'use_cuquantum': False,
         },
         {
-            'backend': None  # older API usage.
+            'backend': CustomSampler(),
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,  # older API usage.
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,
+            'use_cuquantum': True,
         }
     ])
-    def test_sampled_expectation_type_inputs_error(self, backend):
+    def test_sampled_expectation_type_inputs_error(self, backend,
+                                                   use_cuquantum):
         """Test that SampledExpectation errors within Keras call."""
 
         bit = cirq.GridQubit(0, 0)
@@ -124,43 +138,62 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
 
         with self.assertRaisesRegex(RuntimeError,
                                     expected_regex="repetitions not provided"):
-            sampled_expectation.SampledExpectation(backend=backend)(
-                symb_circuit,
-                symbol_names=[symbol],
-                symbol_values=[[0.5]],
-                operators=test_psum)
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )(symb_circuit,
+              symbol_names=[symbol],
+              symbol_values=[[0.5]],
+              operators=test_psum)
 
         with self.assertRaisesRegex(Exception,
                                     expected_regex="Unknown initializer"):
-            sampled_expectation.SampledExpectation(backend=backend)(
-                reg_circuit,
-                operators=test_psum,
-                initializer='junk',
-                repetitions=1)
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )(reg_circuit,
+              operators=test_psum,
+              initializer='junk',
+              repetitions=1)
 
         with self.assertRaisesRegex(Exception,
                                     expected_regex="cannot be parsed"):
-            sampled_expectation.SampledExpectation(backend=backend)(
-                reg_circuit, operators=test_psum, repetitions='junk')
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )(reg_circuit, operators=test_psum, repetitions='junk')
 
     @parameterized.parameters([
         {
-            'backend': 'noisy'
+            'backend': 'noisy',
+            'use_cuquantum': False,
         },
         {
-            'backend': 'noiseless'
+            'backend': 'noiseless',
+            'use_cuquantum': False,
         },
         {
-            'backend': cirq.Simulator()
+            'backend': 'noiseless',
+            'use_cuquantum': True,
         },
         {
-            'backend': CustomSampler()
+            'backend': cirq.Simulator(),
+            'use_cuquantum': False,
         },
         {
-            'backend': None  # older API usage.
+            'backend': CustomSampler(),
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,  # older API usage.
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,
+            'use_cuquantum': True,
         }
     ])
-    def test_sampled_expectation_op_error(self, backend):
+    def test_sampled_expectation_op_error(self, backend, use_cuquantum):
         """Test that expectation errors within underlying ops correctly."""
         # Note the expected_regex is left blank here since there is a
         # discrepancy between the error strings provided between backends.
@@ -173,72 +206,97 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
 
         with self.assertRaisesRegex(Exception, expected_regex="pauli"):
             # Operators has wrong rank. Parse error.
-            sampled_expectation.SampledExpectation(backend=backend)(
-                [reg_circuit],
-                operators=util.convert_to_tensor([test_psum]),
-                repetitions=1)
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )([reg_circuit],
+              operators=util.convert_to_tensor([test_psum]),
+              repetitions=1)
 
         with self.assertRaisesRegex(Exception, expected_regex="symbol_values"):
             # symbol_values has wrong rank.
-            sampled_expectation.SampledExpectation(backend=backend)(
-                [symb_circuit],
-                symbol_names=[symbol],
-                symbol_values=[0.5],
-                operators=test_psum,
-                repetitions=1)
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )([symb_circuit],
+              symbol_names=[symbol],
+              symbol_values=[0.5],
+              operators=test_psum,
+              repetitions=1)
 
         with self.assertRaisesRegex(Exception, expected_regex="pauli"):
             # Wrong batch size for pauli operators.
-            sampled_expectation.SampledExpectation(backend=backend)(
-                symb_circuit,
-                symbol_names=[symbol],
-                operators=[[test_psum], [test_psum]],
-                repetitions=1)
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )(symb_circuit,
+              symbol_names=[symbol],
+              operators=[[test_psum], [test_psum]],
+              repetitions=1)
 
         with self.assertRaisesRegex(Exception, expected_regex="pauli"):
             # Wrong batch size for pauli operators.
-            sampled_expectation.SampledExpectation(backend=backend)(
-                reg_circuit,
-                operators=[[test_psum], [test_psum]],
-                repetitions=1)
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )(reg_circuit, operators=[[test_psum], [test_psum]], repetitions=1)
 
         with self.assertRaisesRegex(Exception, expected_regex="0"):
             # Wrong repetitions.
-            sampled_expectation.SampledExpectation(backend=backend)(
-                reg_circuit, operators=test_psum, repetitions=-1)
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )(reg_circuit, operators=test_psum, repetitions=-1)
 
         with self.assertRaisesRegex(Exception, expected_regex=""):
             # Wrong second dimension size for repetitions & pauli operators.
-            sampled_expectation.SampledExpectation(backend=backend)(
-                reg_circuit, operators=test_psum, repetitions=[5, 4, 3])
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )(reg_circuit, operators=test_psum, repetitions=[5, 4, 3])
 
         with self.assertRaisesRegex(Exception, expected_regex=""):
             # Wrong batch_size for symbol values.
-            sampled_expectation.SampledExpectation(backend=backend)(
-                [reg_circuit],
-                symbol_names=[symbol],
-                symbol_values=np.zeros((3, 1)),
-                operators=test_psum,
-                repetitions=5)
+            sampled_expectation.SampledExpectation(
+                backend=backend,
+                use_cuquantum=use_cuquantum,
+            )([reg_circuit],
+              symbol_names=[symbol],
+              symbol_values=np.zeros((3, 1)),
+              operators=test_psum,
+              repetitions=5)
 
     @parameterized.parameters([
         {
-            'backend': 'noisy'
+            'backend': 'noisy',
+            'use_cuquantum': False,
         },
         {
-            'backend': 'noiseless'
+            'backend': 'noiseless',
+            'use_cuquantum': False,
         },
         {
-            'backend': cirq.Simulator()
+            'backend': 'noiseless',
+            'use_cuquantum': True,
         },
         {
-            'backend': CustomSampler()
+            'backend': cirq.Simulator(),
+            'use_cuquantum': False,
         },
         {
-            'backend': None  # older API usage.
+            'backend': CustomSampler(),
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,  # older API usage.
+            'use_cuquantum': False,
+        },
+        {
+            'backend': None,
+            'use_cuquantum': True,
         }
     ])
-    def test_static_cases(self, backend):
+    def test_static_cases(self, backend, use_cuquantum):
         """Run inputs through in complex cases."""
 
         bit = cirq.GridQubit(0, 0)
@@ -249,59 +307,77 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
         reg_circuit = cirq.Circuit(cirq.H(bit))
 
         # Passing a 2d operators input requires a 1d circuit input.
-        sampled_expectation.SampledExpectation(backend=backend)(
-            [reg_circuit, reg_circuit],
-            operators=[[test_psum, test_psum], [test_psum, test_psum]],
-            repetitions=1)
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )([reg_circuit, reg_circuit],
+          operators=[[test_psum, test_psum], [test_psum, test_psum]],
+          repetitions=1)
 
         # Passing 2d operators along with other inputs.
-        sampled_expectation.SampledExpectation(backend=backend)(
-            [symb_circuit, symb_circuit],
-            symbol_names=[symbol],
-            operators=[[test_psum, test_psum], [test_psum, test_psum]],
-            repetitions=1)
-        sampled_expectation.SampledExpectation(backend=backend)(
-            [symb_circuit, symb_circuit],
-            symbol_names=[symbol],
-            symbol_values=[[0.5], [0.8]],
-            operators=[[test_psum, test_psum], [test_psum, test_psum]],
-            repetitions=1)
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )([symb_circuit, symb_circuit],
+          symbol_names=[symbol],
+          operators=[[test_psum, test_psum], [test_psum, test_psum]],
+          repetitions=1)
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )([symb_circuit, symb_circuit],
+          symbol_names=[symbol],
+          symbol_values=[[0.5], [0.8]],
+          operators=[[test_psum, test_psum], [test_psum, test_psum]],
+          repetitions=1)
 
         # Ensure tiling up of circuits works as expected.
-        sampled_expectation.SampledExpectation(backend=backend)(
-            reg_circuit, operators=test_psum, repetitions=1)
-        sampled_expectation.SampledExpectation(backend=backend)(
-            reg_circuit, operators=[test_psum, test_psum], repetitions=1)
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(reg_circuit, operators=test_psum, repetitions=1)
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(reg_circuit, operators=[test_psum, test_psum], repetitions=1)
 
         # Ensure tiling up of symbol_values works as expected.
-        sampled_expectation.SampledExpectation(backend=backend)(
-            symb_circuit,
-            symbol_names=[symbol],
-            symbol_values=[[0.5], [0.8]],
-            operators=test_psum,
-            repetitions=1)
-        sampled_expectation.SampledExpectation(backend=backend)(
-            symb_circuit,
-            symbol_names=[symbol],
-            symbol_values=[[0.5]],
-            operators=test_psum,
-            repetitions=1)
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(symb_circuit,
+          symbol_names=[symbol],
+          symbol_values=[[0.5], [0.8]],
+          operators=test_psum,
+          repetitions=1)
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(symb_circuit,
+          symbol_names=[symbol],
+          symbol_values=[[0.5]],
+          operators=test_psum,
+          repetitions=1)
 
         # Test multiple operators with integer valued repetition.
-        sampled_expectation.SampledExpectation(backend=backend)(
-            symb_circuit,
-            symbol_names=[symbol],
-            symbol_values=[[0.5]],
-            operators=[-1.0 * cirq.Z(bit),
-                       cirq.X(bit) + 2.0 * cirq.Z(bit)],
-            repetitions=1)
-        sampled_expectation.SampledExpectation(backend=backend)(
-            symb_circuit,
-            symbol_names=[symbol],
-            symbol_values=[[0.5]],
-            operators=[-1.0 * cirq.Z(bit),
-                       cirq.X(bit) + 2.0 * cirq.Z(bit)],
-            repetitions=[5, 1])
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(symb_circuit,
+          symbol_names=[symbol],
+          symbol_values=[[0.5]],
+          operators=[-1.0 * cirq.Z(bit),
+                     cirq.X(bit) + 2.0 * cirq.Z(bit)],
+          repetitions=1)
+        sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(symb_circuit,
+          symbol_names=[symbol],
+          symbol_values=[[0.5]],
+          operators=[-1.0 * cirq.Z(bit),
+                     cirq.X(bit) + 2.0 * cirq.Z(bit)],
+          repetitions=[5, 1])
 
     def test_sampled_expectation_simple_tf_train(self):
         """Train a layer using standard tf (not keras)."""
@@ -325,8 +401,17 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
                                         tf.test.TestCase):
     """Test hybrid/integrated models that include a SampledExpectation layer."""
 
-    @parameterized.parameters([{'backend': 'noisy'}, {'backend': 'noiseless'}])
-    def test_simple_param_value_input(self, backend):
+    @parameterized.parameters([{
+        'backend': 'noisy',
+        'use_cuquantum': False,
+    }, {
+        'backend': 'noiseless',
+        'use_cuquantum': False,
+    }, {
+        'backend': 'noiseless',
+        'use_cuquantum': True,
+    }])
+    def test_simple_param_value_input(self, backend, use_cuquantum):
         """Train a densely connected hybrid model.
 
         This model will put a qubit in the zero or one state from a random state
@@ -341,12 +426,14 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         datum = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
         l1 = tf.keras.layers.Dense(10)(inputs)
         l2 = tf.keras.layers.Dense(3)(l1)
-        outputs = sampled_expectation.SampledExpectation(backend=backend)(
-            datum,
-            symbol_names=symbols,
-            operators=cirq.Z(bit),
-            symbol_values=l2,
-            repetitions=5000)
+        outputs = sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(datum,
+          symbol_names=symbols,
+          operators=cirq.Z(bit),
+          symbol_values=l2,
+          repetitions=5000)
         model = tf.keras.Model(inputs=[datum, inputs], outputs=outputs)
 
         data_in = np.array([[1], [0]], dtype=np.float32)
@@ -360,8 +447,17 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         history = model.fit(x=[circuits, data_in], y=data_out, epochs=30)
         self.assertAllClose(history.history['loss'][-1], 0, atol=0.3)
 
-    @parameterized.parameters([{'backend': 'noisy'}, {'backend': 'noiseless'}])
-    def test_simple_op_input(self, backend):
+    @parameterized.parameters([{
+        'backend': 'noisy',
+        'use_cuquantum': False,
+    }, {
+        'backend': 'noiseless',
+        'use_cuquantum': False,
+    }, {
+        'backend': 'noiseless',
+        'use_cuquantum': True,
+    }])
+    def test_simple_op_input(self, backend, use_cuquantum):
         """Test a simple operator input
 
         Learn qubit in the z+ state using two different measurement operators.
@@ -381,10 +477,12 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         n_inp = tf.keras.Input(shape=(1,), dtype=tf.dtypes.int32)
         circuit_inp = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
         circuit_output = sampled_expectation.SampledExpectation(
-            backend=backend)(circuit_inp,
-                             symbol_names=symbols,
-                             operators=op_inp,
-                             repetitions=n_inp)
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(circuit_inp,
+          symbol_names=symbols,
+          operators=op_inp,
+          repetitions=n_inp)
         model = tf.keras.Model(inputs=[circuit_inp, op_inp, n_inp],
                                outputs=[circuit_output])
 
@@ -399,8 +497,17 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
 
         self.assertAllClose(history.history['loss'][-1], 0, atol=1e-2)
 
-    @parameterized.parameters([{'backend': 'noisy'}, {'backend': 'noiseless'}])
-    def test_simple_op_and_param_input(self, backend):
+    @parameterized.parameters([{
+        'backend': 'noisy',
+        'use_cuquantum': False,
+    }, {
+        'backend': 'noiseless',
+        'use_cuquantum': False,
+    }, {
+        'backend': 'noiseless',
+        'use_cuquantum': True,
+    }])
+    def test_simple_op_and_param_input(self, backend, use_cuquantum):
         """Test a simple operator and parameter input.
 
         Train a NN to put a qubit in the z+ or x+ states based on a classical
@@ -424,11 +531,13 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         dense_1 = tf.keras.layers.Dense(10)(data_inp)
         dense_2 = tf.keras.layers.Dense(3)(dense_1)
         circuit_output = sampled_expectation.SampledExpectation(
-            backend=backend)(circuit_inp,
-                             symbol_names=symbols,
-                             symbol_values=dense_2,
-                             operators=op_inp,
-                             repetitions=n_inp)
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(circuit_inp,
+          symbol_names=symbols,
+          symbol_values=dense_2,
+          operators=op_inp,
+          repetitions=n_inp)
 
         functional_model = tf.keras.Model(
             inputs=[circuit_inp, data_inp, op_inp, n_inp],
@@ -443,8 +552,17 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
                                        epochs=20)
         self.assertAllClose(history.history['loss'][-1], 0, atol=3)
 
-    @parameterized.parameters([{'backend': 'noisy'}, {'backend': 'noiseless'}])
-    def test_dnn_qnn_dnn(self, backend):
+    @parameterized.parameters([{
+        'backend': 'noisy',
+        'use_cuquantum': False,
+    }, {
+        'backend': 'noiseless',
+        'use_cuquantum': False,
+    }, {
+        'backend': 'noiseless',
+        'use_cuquantum': True,
+    }])
+    def test_dnn_qnn_dnn(self, backend, use_cuquantum):
         """Train a fully hybrid network using an SampledExpectation layer.
 
         Train the network to output +-5 given an input of 1 or 0. This tests
@@ -463,12 +581,14 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         circuit_input = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
         d1 = tf.keras.layers.Dense(10)(classical_input)
         d2 = tf.keras.layers.Dense(3)(d1)
-        quantum = sampled_expectation.SampledExpectation(backend=backend)(
-            circuit_input,
-            symbol_names=symbols,
-            symbol_values=d2,
-            operators=cirq.Z(bit),
-            repetitions=5000)
+        quantum = sampled_expectation.SampledExpectation(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )(circuit_input,
+          symbol_names=symbols,
+          symbol_values=d2,
+          operators=cirq.Z(bit),
+          repetitions=5000)
         d3 = tf.keras.layers.Dense(1)(quantum)
 
         model = tf.keras.Model(inputs=[circuit_input, classical_input],

--- a/tensorflow_quantum/python/layers/circuit_executors/state.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/state.py
@@ -129,8 +129,8 @@ class State(tf.keras.layers.Layer):
             use_cuquantum: Calls TFQ GPU version op.
         """
         super().__init__(**kwargs)
-        self.state_op = circuit_execution_ops.get_state_op(backend, \
-                                                           use_cuquantum=use_cuquantum)
+        self.state_op = circuit_execution_ops.get_state_op(
+            backend, use_cuquantum=use_cuquantum)
 
     def call(self, inputs, *, symbol_names=None, symbol_values=None):
         """Keras call function.

--- a/tensorflow_quantum/python/layers/circuit_executors/state_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/state_test.py
@@ -45,15 +45,21 @@ class StateTest(parameterized.TestCase, tf.test.TestCase):
             state.State('junk')
 
     @parameterized.parameters([{
-        'backend': None
+        'backend': None,
+        'use_cuquantum': False,
     }, {
-        'backend': cirq.Simulator()
+        'backend': None,
+        'use_cuquantum': True,
     }, {
-        'backend': cirq.DensityMatrixSimulator()
+        'backend': cirq.Simulator(),
+        'use_cuquantum': False,
+    }, {
+        'backend': cirq.DensityMatrixSimulator(),
+        'use_cuquantum': False,
     }])
-    def test_state_invalid_combinations(self, backend):
+    def test_state_invalid_combinations(self, backend, use_cuquantum):
         """Test with valid type inputs and valid value, but incorrect combo."""
-        state_calc = state.State(backend)
+        state_calc = state.State(backend, use_cuquantum)
         symbol = sympy.Symbol('alpha')
         circuit = cirq.Circuit(cirq.H(cirq.GridQubit(0, 0))**symbol)
         with self.assertRaisesRegex(Exception, expected_regex=""):
@@ -109,18 +115,26 @@ class StateTest(parameterized.TestCase, tf.test.TestCase):
 
     @parameterized.parameters([
         {
-            'backend_output': (None, WF_OUTPUT)
+            'backend_output': (None, WF_OUTPUT),
+            'use_cuquantum': False,
         },
         {
-            'backend_output': (cirq.sim.sparse_simulator.Simulator(), WF_OUTPUT)
+            'backend_output': (None, WF_OUTPUT),
+            'use_cuquantum': True,
+        },
+        {
+            'backend_output':
+                (cirq.sim.sparse_simulator.Simulator(), WF_OUTPUT),
+            'use_cuquantum': False,
         },
         {
             'backend_output':
                 (cirq.sim.density_matrix_simulator.DensityMatrixSimulator(),
-                 DM_OUTPUT)
+                 DM_OUTPUT),
+            'use_cuquantum': False,
         },
     ])
-    def test_state_output(self, backend_output):
+    def test_state_output(self, backend_output, use_cuquantum):
         """Check that any output type is as expected.
 
         This layer only allows for 2 different outputs, depending on whether a
@@ -130,7 +144,10 @@ class StateTest(parameterized.TestCase, tf.test.TestCase):
         """
         backend = backend_output[0]
         output = backend_output[1]
-        state_executor = state.State(backend=backend)
+        state_executor = state.State(
+            backend=backend,
+            use_cuquantum=use_cuquantum,
+        )
         bits = cirq.GridQubit.rect(1, 2)
         circuit = cirq.Circuit()
         circuit.append(cirq.H.on(bits[0]))

--- a/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
@@ -154,7 +154,7 @@ class ControlledPQC(tf.keras.layers.Layer):
             `sampled_based` is True or it must inherit
             `cirq.sim.simulator.SimulatesExpectationValues` if `sample_based` is
             False.
-        use_cuquantum: Optional Python `bool` indicating whether or not to use 
+        use_cuquantum: Optional Python `bool` indicating whether or not to use
             GPU ops
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.

--- a/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
@@ -242,7 +242,8 @@ class ControlledPQC(tf.keras.layers.Layer):
                                                   use_cuquantum=use_cuquantum)
         else:
             self._layer = sampled_expectation.SampledExpectation(
-                backend=backend, differentiator=differentiator,
+                backend=backend,
+                differentiator=differentiator,
                 use_cuquantum=use_cuquantum)
 
         self._append_layer = elementary.AddCircuit()

--- a/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc.py
@@ -164,8 +164,8 @@ class NoisyControlledPQC(tf.keras.layers.Layer):
             trajectory.
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.
-        use_cuquantum: Optional `bool` indicating whether to use GPU for simulation
-            or not. Defaults to `False`. NOT IMPLEMENTED YET.
+        use_cuquantum: Optional `bool` indicating whether to use GPU for
+            simulation or not. Defaults to `False`. NOT IMPLEMENTED YET.
         """
         super().__init__(**kwargs)
         # Ingest model_circuit.

--- a/tensorflow_quantum/python/layers/high_level/noisy_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_pqc.py
@@ -165,8 +165,8 @@ class NoisyPQC(tf.keras.layers.Layer):
             trajectory.
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.
-        use_cuquantum: Python `bool` indicating whether to use GPU ops (currently
-            not supported/implemented).
+        use_cuquantum: Python `bool` indicating whether to use GPU ops
+            (currently not supported/implemented).
         initializer: Optional `tf.keras.initializer` object to specify how the
             symbols in `model_circuit` should be initialized when creating
             the managed variables.

--- a/tensorflow_quantum/python/layers/high_level/pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/pqc.py
@@ -167,7 +167,8 @@ class PQC(tf.keras.layers.Layer):
             `cirq.sim.simulator.SimulatesExpectationValues` if analytic
             expectations are desired or `cirq.Sampler` if sampled expectations
             are desired.
-        use_cuquantum: Optional Python `bool` indicating whether or not to use GPU ops
+        use_cuquantum: Optional Python `bool` indicating whether or not to use
+            GPU ops.
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.
         initializer: Optional `tf.keras.initializer` object to specify how the

--- a/tensorflow_quantum/python/optimizers/rotosolve_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/rotosolve_minimizer_test.py
@@ -145,7 +145,7 @@ class RotosolveMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         a, b = sympy.symbols('a b')  # parameters for the circuit
         circuit = cirq.Circuit(
             cirq.rx(a).on(q0),
-            cirq.ry(b).on(q1), cirq.CNOT(control=q0, target=q1))
+            cirq.ry(b).on(q1), cirq.CNOT(q0, q1))
 
         # Build the Keras model.
         model = tf.keras.Sequential([

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -248,7 +248,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         a, b = sympy.symbols('a b')  # parameters for the circuit
         circuit = cirq.Circuit(
             cirq.rx(a).on(q0),
-            cirq.ry(b).on(q1), cirq.CNOT(control=q0, target=q1))
+            cirq.ry(b).on(q1), cirq.CNOT(q0, q1))
 
         # Build the Keras model.
         model = tf.keras.Sequential([


### PR DESCRIPTION
- Added `./scripts/test_all.sh gpu` for testing cuquantum ops together.

- For the recent `qsim 0.16.1` compatibility with Cirq, TFQ also needs `Cirq >= 1.0`. In this case, there are some deprecated & changed features.
  - `cirq_google.XMON` was deprecated : https://github.com/quantumlib/Cirq/issues/4856
  - `QuantumEngineSampler` was deprecated : https://github.com/quantumlib/Cirq/issues/5371 
    - So, we need [ProcessorSampler() for testing](https://github.com/quantumlib/Cirq/blob/master/cirq-google/cirq_google/engine/processor_sampler_test.py)
  - `cirq.CNOT` interface was changed.
    - https://quantumai.google/reference/python/cirq/CNOT
    - No more control, target argument.
  - `cirq.SingleQubitGate` was deprecated.
    - For testing, use `cirq.testing.SingleQubitGate` : https://github.com/quantumlib/Cirq/pull/5272/files
    - For implementation, use `cirq.Gate`.

- `ParseContext ProtoParse()` has bug.
  - `2023-05-02 04:52:39.342483: W tensorflow/core/framework/op_kernel.cc:1830] OP_REQUIRES failed at tfq_adj_grad_op_cuquantum.cu.cc:87 : INVALID_ARGUMENT: Unparseable proto: junk` and segfault.
    - It should not segfault the program. For graceful termination, we need to allow OpKernel to run its destructor to return resources including GPU handlers.
- Test_simulate_state_large was too large.
  - 4x4=16 qubits ~ 160 GB.
  - → so, 3x3 = 9 qubits resolves.

- `SampledExpectationCuquantum` op bug
  - `circuit_execution_ops_test:ExecutionOpsConsistentyTest.test_sampled_expectation_no_circuits4` failed
  - Because it has no empty tensor treatment, it fell into segfault.
  
- Lots of warnings fixed:
  - int vs unsigned, size type comparisons e.g. `for (int … → for (size_t …`
  - However, if the iterator decreases (e.g. `i--`), it should use int because it never goes under `0` in `size_t`, it runs forever.

- Adjoint gradient cuquantum op numerical error bug was fixed
  - There was no `BulkSetAmpl()` function for `cuStatevec` state space. so, I temporarily added a cuda kernel.
  - Please remove the temporary hack code after supporting the function in qsim.

- Added 4 Keras major layers (`Expectation`, `SampledExpectation`, `Sample`, `State`) `use_cuquantum` tests.
  - Also, if statements dealing with `backend` and `use_cuquantum` were unified.
  - To support older APIs, `backend == 'noiseless' or backend is None` will be the first condition to check `use_cuquantum` is required or not.
    - It also checks `quantum_concurrent` option together, to make it `False` whenever `use_cuquantum is True`.

- Fixed and verified `./scripts/test_all.sh gpu` passes.