### PR TITLE
Fix ./scripts/test_all.sh for CPU mode to be testable and passed

### DIFF
--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -19,12 +19,16 @@ ENABLE_CUDA=${1}
 if [[ ${ENABLE_CUDA} == "gpu" ]]; then
   echo "GPU mode. CUDA config is set."
   CUDA_CONFIG="--config=cuda"
+  # Tests all including cuquantum ops.
+  TAG_FILTER=""
 else
   echo "CPU mode."
   CUDA_CONFIG=""
+  # Tests cpu only excluding cuquantum ops.
+  TAG_FILTER="--test_tag_filters=-cuquantum --build_tag_filters=-cuquantum"
 fi
 
-test_outputs=$(bazel test -c opt ${CUDA_CONFIG} --experimental_repo_remote_exec --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" --cxxopt="-std=c++17" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --test_output=errors //tensorflow_quantum/...)
+test_outputs=$(bazel test -c opt ${CUDA_CONFIG} ${TAG_FILTER} --experimental_repo_remote_exec --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" --cxxopt="-std=c++17" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --test_output=errors //tensorflow_quantum/...)
 exit_code=$?
 if [ "$exit_code" == "0" ]; then
 	echo "Testing Complete!";

--- a/tensorflow_quantum/core/ops/BUILD
+++ b/tensorflow_quantum/core/ops/BUILD
@@ -652,6 +652,7 @@ py_library(
         # tensorflow framework for wrappers
         ":load_module",
     ],
+    tags = ["cuquantum"],
 )
 
 py_test(
@@ -748,6 +749,7 @@ cc_binary(
         "@local_config_cuquantum//:libcuquantum",
         "@qsim//lib:qsim_cuquantum_lib",
     ]),
+    tags = ["cuquantum"],
     # alwayslink=1,
 )
 
@@ -824,6 +826,7 @@ cc_binary(
         "@local_config_cuquantum//:libcuquantum",
         "@qsim//lib:qsim_cuquantum_lib",
     ]),
+    tags = ["cuquantum"],
     # alwayslink=1,
 )
 
@@ -838,6 +841,7 @@ py_library(
         # projector sum cc proto
         # tensorflow framework for wrappers
     ],
+    tags = ["cuquantum"],
 )
 
 py_test(

--- a/tensorflow_quantum/core/ops/circuit_execution_ops.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops.py
@@ -18,9 +18,20 @@ import enum
 import cirq
 
 from tensorflow_quantum.core.ops import (cirq_ops, tfq_simulate_ops,
-                                         tfq_utility_ops,
-                                         tfq_simulate_ops_cuquantum)
+                                         tfq_utility_ops)
 from tensorflow_quantum.python import quantum_context
+
+try:
+    from tensorflow_quantum.core.ops import tfq_simulate_ops_cuquantum
+    _enable_use_cuquantum = True
+except:
+    # `_enable_use_cuquantum = False` makes `use_cuquantum` silent.
+    _enable_use_cuquantum = False
+    tfq_simulate_ops_cuquantum = tfq_simulate_ops
+
+
+def is_cuda_configured() -> bool:
+    return _enable_use_cuquantum
 
 
 class TFQStateVectorSimulator(enum.Enum):
@@ -34,10 +45,12 @@ class TFQStateVectorSimulator(enum.Enum):
     state = tfq_simulate_ops.tfq_simulate_state
     state_cuquantum = tfq_simulate_ops_cuquantum.tfq_simulate_state
 
-    sampled_expectation = \
+    sampled_expectation = (
         tfq_simulate_ops.tfq_simulate_sampled_expectation
-    sampled_expectation_cuquantum = \
+    )
+    sampled_expectation_cuquantum = (
         tfq_simulate_ops_cuquantum.tfq_simulate_sampled_expectation
+    )
 
 
 def _check_quantum_concurrent(quantum_concurrent, use_cuquantum):
@@ -135,9 +148,9 @@ def get_expectation_op(
                 expectation value for each circuit with each op applied to it
                 (after resolving the corresponding parameters in).
     """
-
     # TODO (mbbrough): investigate how the above docstring renders.
     _check_quantum_concurrent(quantum_concurrent, use_cuquantum)
+    use_cuquantum = _enable_use_cuquantum and use_cuquantum
 
     op = None
     if backend is None:
@@ -243,6 +256,7 @@ def get_sampling_op(
 
     # TODO (mbbrough): investigate how the above docstring renders.
     _check_quantum_concurrent(quantum_concurrent, use_cuquantum)
+    use_cuquantum = _enable_use_cuquantum and use_cuquantum
 
     op = None
     if backend is None:
@@ -338,6 +352,7 @@ def get_state_op(
 
     # TODO (mbbrough): investigate how the above docstring renders.
     _check_quantum_concurrent(quantum_concurrent, use_cuquantum)
+    use_cuquantum = _enable_use_cuquantum and use_cuquantum
 
     op = None
     if backend is None:
@@ -455,12 +470,12 @@ def get_sampled_expectation_op(
     """
     # TODO (mbbrough): investigate how the above docstring renders.
     _check_quantum_concurrent(quantum_concurrent, use_cuquantum)
+    use_cuquantum = _enable_use_cuquantum and use_cuquantum
 
     op = None
     if backend is None:
         if use_cuquantum:
             op = TFQStateVectorSimulator.sampled_expectation_cuquantum
-            quantum_concurrent = False
         else:
             op = TFQStateVectorSimulator.sampled_expectation
 

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
@@ -209,7 +209,7 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
         // sv now contains psi
         // scratch contains (sum_j paulis_sums[i][j] * downstream_grads[j])|psi>
         // scratch2 now contains psi as well.
-        [[maybe_unused]] AccumulateOperators(pauli_sums[i], downstream_grads[i],
+        [[maybe_unused]] Status unused = AccumulateOperators(pauli_sums[i], downstream_grads[i],
                                              sim, ss, sv, scratch2, scratch);
 
         for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {
@@ -322,7 +322,7 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
       // sv now contains psi
       // scratch contains (sum_j paulis_sums[i][j] * downstream_grads[j])|psi>
       // scratch2 now contains psi as well.
-      [[maybe_unused]] AccumulateOperators(pauli_sums[i], downstream_grads[i],
+      [[maybe_unused]] Status unused = AccumulateOperators(pauli_sums[i], downstream_grads[i],
                                            sim, ss, sv, scratch2, scratch);
 
       for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.cu.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.cu.cc
@@ -246,7 +246,7 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
       // sv now contains psi
       // scratch contains (sum_j paulis_sums[i][j] * downstream_grads[j])|psi>
       // scratch2 now contains psi as well.
-      [[maybe_unused]] AccumulateOperators(pauli_sums[i], downstream_grads[i],
+      [[maybe_unused]] Status unused = AccumulateOperators(pauli_sums[i], downstream_grads[i],
                                            sim, ss, sv, scratch2, scratch);
 
       for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {

--- a/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
@@ -54,7 +54,7 @@ class TfqCircuitAppendOp : public tensorflow::OpKernel {
     auto DoWork = [&](int start, int end) {
       std::string temp;
       for (int i = start; i < end; i++) {
-        for (size_t j = 0;
+        for (int j = 0;
              j < programs_to_append.at(i).circuit().moments().size(); j++) {
           Moment *new_moment = programs.at(i).mutable_circuit()->add_moments();
           *new_moment = programs_to_append.at(i).circuit().moments(j);

--- a/tensorflow_quantum/python/differentiators/adjoint.py
+++ b/tensorflow_quantum/python/differentiators/adjoint.py
@@ -15,8 +15,15 @@
 """Compute gradients by combining function values linearly."""
 import tensorflow as tf
 
-from tensorflow_quantum.core.ops import tfq_adj_grad_op, \
-                                        tfq_adj_grad_op_cuquantum
+from tensorflow_quantum.core.ops import tfq_adj_grad_op
+try:
+    from tensorflow_quantum.core.ops import tfq_adj_grad_op_cuquantum
+    _enable_use_cuquantum = True
+except:
+    _enable_use_cuquantum = False
+    tfq_adj_grad_op_cuquantum = tfq_adj_grad_op
+
+
 from tensorflow_quantum.python.differentiators import differentiator
 
 

--- a/tensorflow_quantum/python/differentiators/differentiator.py
+++ b/tensorflow_quantum/python/differentiators/differentiator.py
@@ -340,6 +340,14 @@ class Differentiator(metaclass=abc.ABCMeta):
 
     @catch_empty_inputs
     @tf.function
+    def differentiate_analytic_cuquantum(self, programs, symbol_names, symbol_values,
+                               pauli_sums, forward_pass_vals, grad):
+        # `self.expectation_op` is already set to cuquantum op.
+        return self.differentiate_analytic(programs, symbol_names, symbol_values,
+                               pauli_sums, forward_pass_vals, grad)
+
+    @catch_empty_inputs
+    @tf.function
     def differentiate_analytic(self, programs, symbol_names, symbol_values,
                                pauli_sums, forward_pass_vals, grad):
         """Differentiate a circuit with analytical expectation.


### PR DESCRIPTION
With filtering builds / tests tags in Bazel library and tests, we can make CPU mode and GPU mode tests all verified and testable.

Also, added `tensorflow_quantum/core/ops/circuit_execution_ops.py:is_cuda_configured()` function to check if GPU is enabled in TFQ, because we are currently depending on TF CPU lib and TF CPU lib doesn't provide this function.