### PR TITLE
Fix BulkSetAmpl bug, Add more diff cuquantum unit tests

### DIFF
--- a/benchmarks/scripts/benchmark_clifford_circuit.py
+++ b/benchmarks/scripts/benchmark_clifford_circuit.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Benchmark simulators against classically simulatable circuits."""
 import os
 import time

--- a/benchmarks/scripts/benchmark_op_gradients.py
+++ b/benchmarks/scripts/benchmark_op_gradients.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Benchmark differentiator methods."""
 import os
 import time

--- a/benchmarks/scripts/benchmark_random_circuit.py
+++ b/benchmarks/scripts/benchmark_random_circuit.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Benchmark simulators against classically intractable 'supremacy' circuits."""
 import os
 import time

--- a/benchmarks/scripts/benchmark_util.py
+++ b/benchmarks/scripts/benchmark_util.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Utility functions for benchmark tools."""
 import tensorflow as tf
 import test_log_pb2

--- a/benchmarks/scripts/benchmark_util_test.py
+++ b/benchmarks/scripts/benchmark_util_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for utilities related to reading/running benchmarks."""
 import os
 import tempfile

--- a/benchmarks/scripts/flags.py
+++ b/benchmarks/scripts/flags.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Command line flags shared between benchmarks."""
 from collections import namedtuple
 from absl import flags as absl_flags

--- a/benchmarks/scripts/flags_test.py
+++ b/benchmarks/scripts/flags_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for benchmark command line flags."""
 
 import tensorflow as tf

--- a/benchmarks/scripts/models/__init__.py
+++ b/benchmarks/scripts/models/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================

--- a/benchmarks/scripts/models/random_clifford_circuit.py
+++ b/benchmarks/scripts/models/random_clifford_circuit.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 
 from typing import Iterable
 

--- a/benchmarks/scripts/models/random_clifford_circuit_test.py
+++ b/benchmarks/scripts/models/random_clifford_circuit_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 
 from absl.testing import parameterized
 import cirq

--- a/configure.sh
+++ b/configure.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
 
 function write_to_bazelrc() {

--- a/release/build_pip_package.sh
+++ b/release/build_pip_package.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 set -e
 set -x
 

--- a/release/setup.py
+++ b/release/setup.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """TensorFlow Quantum adds qauntum computing primitives to TensorFlow.
 
 TensorFlow Quantum is an open source library for high performance batch

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 echo "Testing benchmarks.";
 test_outputs=$(bazel test -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --test_output=errors $(bazel query //benchmarks/...))
 exit_code=$?

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tool to generate external api_docs for tfq."""
 
 from __future__ import absolute_import

--- a/scripts/build_pip_package_test.sh
+++ b/scripts/build_pip_package_test.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 
 pip install -r requirements.txt
 

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 wget https://github.com/bazelbuild/bazel/releases/download/5.3.0/bazel_5.3.0-linux-x86_64.deb
 sudo dpkg -i bazel_5.3.0-linux-x86_64.deb
 pip install --upgrade pip setuptools wheel

--- a/scripts/ci_validate_tutorials.sh
+++ b/scripts/ci_validate_tutorials.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 
 # Run the tutorials using the installed pip package
 pip install jupyter nbclient==0.6.5 jupyter-client==6.1.12 ipython==7.22.0

--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 echo "Doing python language formatting..."
 python3 -m yapf --style=google --in-place --recursive ./benchmarks
 python3 -m yapf --style=google --in-place --recursive ./tensorflow_quantum

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 echo "Checking python formatting...";
 
 ################################################################################

--- a/scripts/format_ipynb.py
+++ b/scripts/format_ipynb.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Format notebook code cells using yapf google style."""
 import glob
 import nbformat

--- a/scripts/import_test.py
+++ b/scripts/import_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests to check if importing `tfq` APIs is successful or not."""
 import tensorflow_quantum as tfq
 

--- a/scripts/lint_all.sh
+++ b/scripts/lint_all.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 echo "Checking for lint in python code...";
 linting_outputs=$(pylint --rcfile .pylintrc ./tensorflow_quantum ./examples);
 exit_code=$?

--- a/scripts/msan_test.sh
+++ b/scripts/msan_test.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 echo "Testing All Bazel cc_tests with msan.";
 test_outputs=$(bazel test -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" \
   --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" \

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 cd ..
 cp quantum/scripts/import_test.py import_test.py
 python import_test.py

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 echo "Testing All Bazel py_test and cc_tests.";
 ENABLE_CUDA=${1}
 

--- a/scripts/test_benchmarks.sh
+++ b/scripts/test_benchmarks.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 echo "Testing all Benchmarks.";
 bazel test -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --test_output=errors $(bazel query //benchmarks/scripts:all)
 # test_outputs=$(bazel test -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --test_output=errors $(bazel query //benchmarks/scripts:all))

--- a/scripts/test_tutorials.py
+++ b/scripts/test_tutorials.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to ensure all notebooks execute without error by pytesting them."""
 import glob
 import re

--- a/tensorflow_quantum/__init__.py
+++ b/tensorflow_quantum/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module functions for tensorflow_quantum.*"""
 
 # Import basic ops and op getters.

--- a/tensorflow_quantum/core/__init__.py
+++ b/tensorflow_quantum/core/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Imports to tensorflow_quantum.core.* level."""
 # Import getters for constructing ops.
 from tensorflow_quantum.core.ops import (get_expectation_op,

--- a/tensorflow_quantum/core/ops/__init__.py
+++ b/tensorflow_quantum/core/ops/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.core.ops.*"""
 
 # Import getters for constructing ops.

--- a/tensorflow_quantum/core/ops/batch_util.py
+++ b/tensorflow_quantum/core/ops/batch_util.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A module to for running Cirq objects."""
 import collections
 

--- a/tensorflow_quantum/core/ops/batch_util_test.py
+++ b/tensorflow_quantum/core/ops/batch_util_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test parallel Cirq simulations."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/circuit_execution_ops.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops.py
@@ -23,15 +23,16 @@ from tensorflow_quantum.python import quantum_context
 
 try:
     from tensorflow_quantum.core.ops import tfq_simulate_ops_cuquantum
-    _enable_use_cuquantum = True
+    _ENABLE_USE_CUQUANTUM = True
 except:
-    # `_enable_use_cuquantum = False` makes `use_cuquantum` silent.
-    _enable_use_cuquantum = False
+    # `_ENABLE_USE_CUQUANTUM = False` makes `use_cuquantum` silent.
+    _ENABLE_USE_CUQUANTUM = False
     tfq_simulate_ops_cuquantum = tfq_simulate_ops
 
 
-def is_cuda_configured() -> bool:
-    return _enable_use_cuquantum
+def is_gpu_configured() -> bool:
+    """Returns True if gpu ops are available or not."""
+    return _ENABLE_USE_CUQUANTUM
 
 
 class TFQStateVectorSimulator(enum.Enum):
@@ -147,7 +148,7 @@ def get_expectation_op(
     """
     # TODO (mbbrough): investigate how the above docstring renders.
     _check_quantum_concurrent(quantum_concurrent, use_cuquantum)
-    use_cuquantum = _enable_use_cuquantum and use_cuquantum
+    use_cuquantum = _ENABLE_USE_CUQUANTUM and use_cuquantum
 
     op = None
     if backend is None:
@@ -253,7 +254,7 @@ def get_sampling_op(
 
     # TODO (mbbrough): investigate how the above docstring renders.
     _check_quantum_concurrent(quantum_concurrent, use_cuquantum)
-    use_cuquantum = _enable_use_cuquantum and use_cuquantum
+    use_cuquantum = _ENABLE_USE_CUQUANTUM and use_cuquantum
 
     op = None
     if backend is None:
@@ -349,7 +350,7 @@ def get_state_op(
 
     # TODO (mbbrough): investigate how the above docstring renders.
     _check_quantum_concurrent(quantum_concurrent, use_cuquantum)
-    use_cuquantum = _enable_use_cuquantum and use_cuquantum
+    use_cuquantum = _ENABLE_USE_CUQUANTUM and use_cuquantum
 
     op = None
     if backend is None:
@@ -467,7 +468,7 @@ def get_sampled_expectation_op(
     """
     # TODO (mbbrough): investigate how the above docstring renders.
     _check_quantum_concurrent(quantum_concurrent, use_cuquantum)
-    use_cuquantum = _enable_use_cuquantum and use_cuquantum
+    use_cuquantum = _ENABLE_USE_CUQUANTUM and use_cuquantum
 
     op = None
     if backend is None:

--- a/tensorflow_quantum/core/ops/circuit_execution_ops.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops.py
@@ -46,7 +46,7 @@ class TFQStateVectorSimulator(enum.Enum):
     state = tfq_simulate_ops.tfq_simulate_state
     state_cuquantum = tfq_simulate_ops_cuquantum.tfq_simulate_state
 
-    sampled_expectation = (tfq_simulate_ops.tfq_simulate_sampled_expectation)
+    sampled_expectation = tfq_simulate_ops.tfq_simulate_sampled_expectation
     sampled_expectation_cuquantum = (
         tfq_simulate_ops_cuquantum.tfq_simulate_sampled_expectation)
 

--- a/tensorflow_quantum/core/ops/circuit_execution_ops.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops.py
@@ -45,12 +45,9 @@ class TFQStateVectorSimulator(enum.Enum):
     state = tfq_simulate_ops.tfq_simulate_state
     state_cuquantum = tfq_simulate_ops_cuquantum.tfq_simulate_state
 
-    sampled_expectation = (
-        tfq_simulate_ops.tfq_simulate_sampled_expectation
-    )
+    sampled_expectation = (tfq_simulate_ops.tfq_simulate_sampled_expectation)
     sampled_expectation_cuquantum = (
-        tfq_simulate_ops_cuquantum.tfq_simulate_sampled_expectation
-    )
+        tfq_simulate_ops_cuquantum.tfq_simulate_sampled_expectation)
 
 
 def _check_quantum_concurrent(quantum_concurrent, use_cuquantum):

--- a/tensorflow_quantum/core/ops/circuit_execution_ops.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A module for user-facing generators of tfq ops."""
 import enum
 

--- a/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to test consistency between Cirq and TFQ circuit execution ops."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/cirq_ops.py
+++ b/tensorflow_quantum/core/ops/cirq_ops.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Generators for ops that call out to cirq simulators from the tf graph."""
 import functools
 import numbers

--- a/tensorflow_quantum/core/ops/cirq_ops_test.py
+++ b/tensorflow_quantum/core/ops/cirq_ops_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for the cirq simulation ops."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/load_module.py
+++ b/tensorflow_quantum/core/ops/load_module.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to load python op libraries."""
 
 import os

--- a/tensorflow_quantum/core/ops/math_ops/__init__.py
+++ b/tensorflow_quantum/core/ops/math_ops/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.core.ops.math_ops.*"""
 
 from tensorflow_quantum.core.ops.math_ops.fidelity_op import fidelity

--- a/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.math.fidelity op."""
 import tensorflow as tf
 from tensorflow_quantum.core.ops.math_ops import inner_product_op

--- a/tensorflow_quantum/core/ops/math_ops/fidelity_op_test.py
+++ b/tensorflow_quantum/core/ops/math_ops/fidelity_op_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target tfq_inner_product."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_grad_test.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_grad_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target tfq_inner_product_grad."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to register python op gradient."""
 import os
 import tensorflow as tf

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_op_test.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_op_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target tfq_inner_product."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/math_ops/simulate_mps.py
+++ b/tensorflow_quantum/core/ops/math_ops/simulate_mps.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to register MPS simulation ops."""
 import os
 import tensorflow as tf

--- a/tensorflow_quantum/core/ops/math_ops/simulate_mps_test.py
+++ b/tensorflow_quantum/core/ops/math_ops/simulate_mps_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target simulate_mps."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/noise/__init__.py
+++ b/tensorflow_quantum/core/ops/noise/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.core.ops.noise.*"""
 
 from tensorflow_quantum.core.ops.noise.noisy_expectation_op import expectation

--- a/tensorflow_quantum/core/ops/noise/noisy_expectation_op.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_expectation_op.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for high performance noisy circuit simulation ops."""
 import os
 import tensorflow as tf

--- a/tensorflow_quantum/core/ops/noise/noisy_expectation_op_test.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_expectation_op_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target noisy expectation calculation."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for high performance noisy circuit sampled epxectation ops."""
 import os
 import tensorflow as tf

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op_test.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target noisy expectation calculation."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/noise/noisy_samples_op.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_samples_op.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for high performance noisy circuit sampling ops"""
 import os
 import tensorflow as tf

--- a/tensorflow_quantum/core/ops/noise/noisy_samples_op_test.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_samples_op_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target noisy sampling."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
@@ -209,8 +209,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
         // sv now contains psi
         // scratch contains (sum_j paulis_sums[i][j] * downstream_grads[j])|psi>
         // scratch2 now contains psi as well.
-        [[maybe_unused]] Status unused = AccumulateOperators(pauli_sums[i], downstream_grads[i],
-                                             sim, ss, sv, scratch2, scratch);
+        [[maybe_unused]] Status unused = AccumulateOperators(
+            pauli_sums[i], downstream_grads[i], sim, ss, sv, scratch2, scratch);
 
         for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {
           for (int k = partial_fused_circuits[i][j].size() - 1; k >= 0; k--) {
@@ -322,8 +322,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
       // sv now contains psi
       // scratch contains (sum_j paulis_sums[i][j] * downstream_grads[j])|psi>
       // scratch2 now contains psi as well.
-      [[maybe_unused]] Status unused = AccumulateOperators(pauli_sums[i], downstream_grads[i],
-                                           sim, ss, sv, scratch2, scratch);
+      [[maybe_unused]] Status unused = AccumulateOperators(
+          pauli_sums[i], downstream_grads[i], sim, ss, sv, scratch2, scratch);
 
       for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {
         for (int k = partial_fused_circuits[i][j].size() - 1; k >= 0; k--) {

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to register python op gradient."""
 import tensorflow as tf
 from tensorflow_quantum.core.ops.load_module import load_module

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.cu.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.cu.cc
@@ -41,17 +41,16 @@ namespace tfq {
 namespace {
 // TODO(jaeyoo): Temorary hack for BulkSetAmpl with cuda ops.
 // Updates qsim custatevec side BulkSetAmple ops, and remove these utilities.
-template <typename FP, unsigned warp_size = 32>
+template <typename FP>
 __global__ void BulkSetAmplKernel(uint64_t mask, uint64_t bits, FP re, FP im,
                                   bool exclude, FP* state) {
   uint64_t k1 = uint64_t{blockIdx.x} * blockDim.x + threadIdx.x;
-  uint64_t k2 = 2 * k1 - threadIdx.x % warp_size;
 
   bool set = ((k1 & mask) == bits) ^ exclude;
 
   if (set) {
-    state[k2] = re;
-    state[k2 + warp_size] = im;
+    state[2 * k1] = re;
+    state[2 * k1 + 1] = im;
   }
 }
 

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.cu.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.cu.cc
@@ -246,8 +246,8 @@ class TfqAdjointGradientCuquantumOp : public tensorflow::OpKernel {
       // sv now contains psi
       // scratch contains (sum_j paulis_sums[i][j] * downstream_grads[j])|psi>
       // scratch2 now contains psi as well.
-      [[maybe_unused]] Status unused = AccumulateOperators(pauli_sums[i], downstream_grads[i],
-                                           sim, ss, sv, scratch2, scratch);
+      [[maybe_unused]] Status unused = AccumulateOperators(
+          pauli_sums[i], downstream_grads[i], sim, ss, sv, scratch2, scratch);
 
       for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {
         for (int k = partial_fused_circuits[i][j].size() - 1; k >= 0; k--) {

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to register python op gradient."""
 import tensorflow as tf
 from tensorflow_quantum.core.ops.load_module import load_module

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum_test.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum_test.py
@@ -116,7 +116,7 @@ class ADJGradTest(tf.test.TestCase, parameterized.TestCase):
         # The result should be the similar within a tolerance.
         np.testing.assert_allclose(res_cpu,
                                    res_cuquantum,
-                                   atol=1e-3,
+                                   atol=1e-4,
                                    err_msg="""
         # If failed, the GPU architecture in this system may be unsupported.
         # Please refer to the supported architectures here.

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum_test.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_cuquantum_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target tfq_unitary_op."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_test.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target tfq_unitary_op."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
@@ -54,8 +54,8 @@ class TfqCircuitAppendOp : public tensorflow::OpKernel {
     auto DoWork = [&](int start, int end) {
       std::string temp;
       for (int i = start; i < end; i++) {
-        for (int j = 0;
-             j < programs_to_append.at(i).circuit().moments().size(); j++) {
+        for (int j = 0; j < programs_to_append.at(i).circuit().moments().size();
+             j++) {
           Moment *new_moment = programs.at(i).mutable_circuit()->add_moments();
           *new_moment = programs_to_append.at(i).circuit().moments(j);
         }

--- a/tensorflow_quantum/core/ops/tfq_ps_util_ops.py
+++ b/tensorflow_quantum/core/ops/tfq_ps_util_ops.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Expose bindings for ParameterShift C++ ops."""
 from tensorflow_quantum.core.ops.load_module import load_module
 

--- a/tensorflow_quantum/core/ops/tfq_ps_util_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_ps_util_ops_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test for ParameterShift specific C++ ops."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/tfq_simulate_ops.py
+++ b/tensorflow_quantum/core/ops/tfq_simulate_ops.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to register python op gradient."""
 import tensorflow as tf
 from tensorflow_quantum.core.ops.load_module import load_module

--- a/tensorflow_quantum/core/ops/tfq_simulate_ops_cuquantum.py
+++ b/tensorflow_quantum/core/ops/tfq_simulate_ops_cuquantum.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to register cuQuantum simulation python op."""
 import tensorflow as tf
 from tensorflow_quantum.core.ops.load_module import load_module

--- a/tensorflow_quantum/core/ops/tfq_simulate_ops_cuquantum_test.py
+++ b/tensorflow_quantum/core/ops/tfq_simulate_ops_cuquantum_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target tfq_simulate_ops_cu*."""
 import time
 import numpy as np

--- a/tensorflow_quantum/core/ops/tfq_simulate_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_simulate_ops_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target tfq_simulate_ops."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/tfq_unitary_op.py
+++ b/tensorflow_quantum/core/ops/tfq_unitary_op.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to register python op gradient."""
 import tensorflow as tf
 from tensorflow_quantum.core.ops import tfq_utility_ops

--- a/tensorflow_quantum/core/ops/tfq_unitary_op_test.py
+++ b/tensorflow_quantum/core/ops/tfq_unitary_op_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests that specifically target tfq_unitary_op."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/ops/tfq_utility_ops.py
+++ b/tensorflow_quantum/core/ops/tfq_utility_ops.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Expose bindings for tfq utility ops."""
 import tensorflow as tf
 from tensorflow_quantum.core.ops.load_module import load_module

--- a/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for tfq utility ops."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/core/proto/__init__.py
+++ b/tensorflow_quantum/core/proto/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================

--- a/tensorflow_quantum/core/serialize/__init__.py
+++ b/tensorflow_quantum/core/serialize/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.core.serialize.*"""
 from tensorflow_quantum.core.serialize.serializer import (serialize_circuit,
                                                           deserialize_circuit,

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A basic serializer used to serialize/deserialize Cirq circuits for tfq."""
 # TODO(pmassey / anyone): determine if this should be kept as globals.
 import copy

--- a/tensorflow_quantum/core/serialize/serializer_test.py
+++ b/tensorflow_quantum/core/serialize/serializer_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module to test serialization core."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/datasets/__init__.py
+++ b/tensorflow_quantum/datasets/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Experimental location for interesting quantum datasets."""
 # Import to the tensorflow_quantum.datasets.* level."""
 from tensorflow_quantum.datasets.cluster_state import excited_cluster_states

--- a/tensorflow_quantum/datasets/cluster_state.py
+++ b/tensorflow_quantum/datasets/cluster_state.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Toy dataset showing boilerplate code for a cluster state example."""
 import numpy as np
 import cirq

--- a/tensorflow_quantum/datasets/cluster_state_test.py
+++ b/tensorflow_quantum/datasets/cluster_state_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test the cluster state dataset."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/datasets/spin_system.py
+++ b/tensorflow_quantum/datasets/spin_system.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Quantum datasets for quantum many-body spin systems."""
 
 from collections import namedtuple

--- a/tensorflow_quantum/datasets/spin_system_test.py
+++ b/tensorflow_quantum/datasets/spin_system_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test the spin system dataset"""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/__init__.py
+++ b/tensorflow_quantum/python/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module definitions for tensorflow_quantum.python.util.*"""
 from tensorflow_quantum.python.util import (
     # Utility functions.

--- a/tensorflow_quantum/python/differentiators/BUILD
+++ b/tensorflow_quantum/python/differentiators/BUILD
@@ -39,6 +39,7 @@ py_test(
     deps = [
         ":adjoint",
         "//tensorflow_quantum/core/ops:circuit_execution_ops",
+        "//tensorflow_quantum/python:util",
     ],
 )
 
@@ -122,6 +123,7 @@ py_test(
 py_test(
     name = "gradient_test",
     timeout = "eternal",
+    shard_count = 5,
     srcs = ["gradient_test.py"],
     python_version = "PY3",
     deps = [

--- a/tensorflow_quantum/python/differentiators/__init__.py
+++ b/tensorflow_quantum/python/differentiators/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module functions for tfq.differentiators.*"""
 
 from tensorflow_quantum.python.differentiators.adjoint import (

--- a/tensorflow_quantum/python/differentiators/adjoint.py
+++ b/tensorflow_quantum/python/differentiators/adjoint.py
@@ -142,6 +142,21 @@ class Adjoint(differentiator.Differentiator):
         return tfq_adj_grad_op.tfq_adj_grad(programs, symbol_names,
                                             symbol_values, pauli_sums, grad)
 
+    def differentiate_sampled_cuquantum(
+            self,
+            programs,
+            symbol_names,
+            symbol_values,
+            pauli_sums,
+            num_samples,
+            forward_pass_vals,
+            grad,
+    ):
+        raise NotImplementedError(
+            "Adjoint state methods are not supported in sample based settings."
+            " Please use analytic expectation calculation or a different "
+            "tfq.differentiator.")
+
     def differentiate_sampled(
             self,
             programs,

--- a/tensorflow_quantum/python/differentiators/adjoint.py
+++ b/tensorflow_quantum/python/differentiators/adjoint.py
@@ -18,9 +18,9 @@ import tensorflow as tf
 from tensorflow_quantum.core.ops import tfq_adj_grad_op
 try:
     from tensorflow_quantum.core.ops import tfq_adj_grad_op_cuquantum
-    _enable_use_cuquantum = True
+    _ENABLE_USE_CUQUANTUM = True
 except:
-    _enable_use_cuquantum = False
+    _ENABLE_USE_CUQUANTUM = False
     tfq_adj_grad_op_cuquantum = tfq_adj_grad_op
 
 from tensorflow_quantum.python.differentiators import differentiator
@@ -99,6 +99,7 @@ class Adjoint(differentiator.Differentiator):
             raise ValueError("sample base backends are not supported by the "
                              "Adjoint method, please use analytic expectation"
                              " or choose another differentiator.")
+        use_cuquantum = _ENABLE_USE_CUQUANTUM and use_cuquantum
 
         return super().generate_differentiable_op(analytic_op=analytic_op,
                                                   use_cuquantum=use_cuquantum)

--- a/tensorflow_quantum/python/differentiators/adjoint.py
+++ b/tensorflow_quantum/python/differentiators/adjoint.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Compute gradients by combining function values linearly."""
 import tensorflow as tf
 

--- a/tensorflow_quantum/python/differentiators/adjoint.py
+++ b/tensorflow_quantum/python/differentiators/adjoint.py
@@ -23,7 +23,6 @@ except:
     _enable_use_cuquantum = False
     tfq_adj_grad_op_cuquantum = tfq_adj_grad_op
 
-
 from tensorflow_quantum.python.differentiators import differentiator
 
 

--- a/tensorflow_quantum/python/differentiators/adjoint_test.py
+++ b/tensorflow_quantum/python/differentiators/adjoint_test.py
@@ -47,7 +47,7 @@ class AdjointTest(tf.test.TestCase, parameterized.TestCase):
         """Ensure that use_cuquantum switches to cuquantum ops well."""
         if not circuit_execution_ops.is_gpu_configured():
             # Ignores this test if gpu is not configured.
-            self.skipTest()
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         # Prepares a simple circuit.
         qubit = cirq.GridQubit(0, 0)
         circuit = util.convert_to_tensor(
@@ -75,7 +75,7 @@ class AdjointTest(tf.test.TestCase, parameterized.TestCase):
                 g.watch(symbol_values_tensor)
                 expectations = diff_op(circuit, tf.convert_to_tensor(['alpha']),
                                        symbol_values_tensor, psums)
-            grads = g.gradient(expectations, symbol_values_tensor)
+            _ = g.gradient(expectations, symbol_values_tensor)
         mock_adj.assert_called_once()
 
     def test_sample_errors(self):

--- a/tensorflow_quantum/python/differentiators/adjoint_test.py
+++ b/tensorflow_quantum/python/differentiators/adjoint_test.py
@@ -19,19 +19,64 @@ import sys
 NEW_PATH = [x for x in sys.path if 'com_google_protobuf' not in x]
 sys.path = NEW_PATH
 # pylint: enable=wrong-import-position
+from unittest import mock
 
+from absl.testing import parameterized
+import cirq
+import numpy as np
+import sympy
 import tensorflow as tf
 
-from tensorflow_quantum.python.differentiators import adjoint
 from tensorflow_quantum.core.ops import circuit_execution_ops
+from tensorflow_quantum.python import util
+from tensorflow_quantum.python.differentiators import adjoint
 
 
-class AdjointTest(tf.test.TestCase):
+class AdjointTest(tf.test.TestCase, parameterized.TestCase):
     """Test that we can properly subclass differentiator."""
 
     def test_instantiation(self):
         """Test that adjoint can be created."""
         adjoint.Adjoint()
+
+    @parameterized.parameters(
+        list(util.kwargs_cartesian_product(**{
+            'use_cuquantum': [False, True],
+        })))
+    def test_use_cuquantum(self, use_cuquantum):
+        """Ensure that use_cuquantum switches to cuquantum ops well."""
+        if not circuit_execution_ops.is_gpu_configured():
+            # Ignores this test if gpu is not configured.
+            self.skipTest()
+        # Prepares a simple circuit.
+        qubit = cirq.GridQubit(0, 0)
+        circuit = util.convert_to_tensor(
+            [cirq.Circuit(cirq.X(qubit)**sympy.Symbol('alpha'))])
+        psums = util.convert_to_tensor([[cirq.Z(qubit)]])
+        symbol_values_array = np.array([[0.123]], dtype=np.float32)
+        symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
+
+        # Mocks `Adjoint.differentiate_analytic*()` to check if
+        # it's called once correctly.
+        method_name = ("differentiate_analytic_cuquantum"
+                       if use_cuquantum else "differentiate_analytic")
+        with mock.patch.object(adjoint.Adjoint,
+                               method_name,
+                               return_value=None,
+                               autospec=True) as mock_adj:
+            dif = adjoint.Adjoint()
+            op = circuit_execution_ops.get_expectation_op(
+                use_cuquantum=use_cuquantum, quantum_concurrent=False)
+            diff_op = dif.generate_differentiable_op(
+                analytic_op=op, use_cuquantum=use_cuquantum)
+
+            # Calculate tfq gradient.
+            with tf.GradientTape() as g:
+                g.watch(symbol_values_tensor)
+                expectations = diff_op(circuit, tf.convert_to_tensor(['alpha']),
+                                       symbol_values_tensor, psums)
+            grads = g.gradient(expectations, symbol_values_tensor)
+        mock_adj.assert_called_once()
 
     def test_sample_errors(self):
         """Ensure that the adjoint method won't attach to sample ops."""
@@ -40,6 +85,8 @@ class AdjointTest(tf.test.TestCase):
         op = circuit_execution_ops.get_sampled_expectation_op()
         with self.assertRaisesRegex(ValueError, expected_regex='not supported'):
             dif.generate_differentiable_op(sampled_op=op)
+        with self.assertRaisesRegex(ValueError, expected_regex='not supported'):
+            dif.generate_differentiable_op(sampled_op=op, use_cuquantum=True)
 
     def test_no_gradient_circuits(self):
         """Confirm the adjoint differentiator has no gradient circuits."""

--- a/tensorflow_quantum/python/differentiators/adjoint_test.py
+++ b/tensorflow_quantum/python/differentiators/adjoint_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for the differentiator abstract class."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/differentiators/differentiator.py
+++ b/tensorflow_quantum/python/differentiators/differentiator.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Testing consistency in values across differentiation methods."""
 import abc
 import inspect

--- a/tensorflow_quantum/python/differentiators/differentiator.py
+++ b/tensorflow_quantum/python/differentiators/differentiator.py
@@ -343,7 +343,9 @@ class Differentiator(metaclass=abc.ABCMeta):
     def differentiate_analytic_cuquantum(self, programs, symbol_names,
                                          symbol_values, pauli_sums,
                                          forward_pass_vals, grad):
-        # `self.expectation_op` is already set to cuquantum op.
+        """Differentiate a circuit with analytical expectation with GPU ops."""
+        # `self.expectation_op` is already set to cuquantum op at
+        # generate_differentiable_op._differentiate_ana.
         return self.differentiate_analytic(programs, symbol_names,
                                            symbol_values, pauli_sums,
                                            forward_pass_vals, grad)

--- a/tensorflow_quantum/python/differentiators/differentiator.py
+++ b/tensorflow_quantum/python/differentiators/differentiator.py
@@ -118,6 +118,9 @@ class Differentiator(metaclass=abc.ABCMeta):
             raise TypeError('Provided arguments must be callable tensorflow '
                             'ops.')
 
+        if not isinstance(use_cuquantum, bool):
+            raise TypeError('use_cuquantum should be boolean.')
+
         # TODO (mbbrough): find a better workaround than this to ensure
         #   that the correct sample based expectation wasn't accidentally
         #   put inside of the analytical_op argument or vice versa.
@@ -155,8 +158,12 @@ class Differentiator(metaclass=abc.ABCMeta):
                                      'Given arg: {}.'.format(str(key)) + ''
                                      'The signature should contain: {}.'.format(
                                          list(expected_signature)))
-        _differentiate_ana = (self._differentiate_ana_cq
-                              if use_cuquantum else self._differentiate_ana)
+        if use_cuquantum:
+            _differentiate_ana, _differentiate_sam = (
+                self._differentiate_ana_cq, self._differentiate_sam_cq)
+        else:
+            _differentiate_ana, _differentiate_sam = (self._differentiate_ana,
+                                                      self._differentiate_sam)
 
         @tf.custom_gradient
         def op_wrapper_analytic(programs, symbol_names, symbol_values,
@@ -178,10 +185,9 @@ class Differentiator(metaclass=abc.ABCMeta):
                                            num_samples)
 
             def gradient(grad):
-                return self._differentiate_sam(programs, symbol_names,
-                                               symbol_values, pauli_sums,
-                                               num_samples, forward_pass_vals,
-                                               grad)
+                return _differentiate_sam(programs, symbol_names, symbol_values,
+                                          pauli_sums, num_samples,
+                                          forward_pass_vals, grad)
 
             return forward_pass_vals, gradient
 
@@ -206,6 +212,13 @@ class Differentiator(metaclass=abc.ABCMeta):
             programs, symbol_names, symbol_values,
             pauli_sums, forward_pass_vals, grad), \
                None
+
+    def _differentiate_sam_cq(self, programs, symbol_names, symbol_values,
+                              pauli_sums, num_samples, forward_pass_vals, grad):
+        return None, None, self.differentiate_sampled_cuquantum(
+            programs, symbol_names, symbol_values,
+            pauli_sums, num_samples, forward_pass_vals, grad), \
+               None, None
 
     def _differentiate_sam(self, programs, symbol_names, symbol_values,
                            pauli_sums, num_samples, forward_pass_vals, grad):
@@ -349,6 +362,18 @@ class Differentiator(metaclass=abc.ABCMeta):
         return self.differentiate_analytic(programs, symbol_names,
                                            symbol_values, pauli_sums,
                                            forward_pass_vals, grad)
+
+    @catch_empty_inputs
+    @tf.function
+    def differentiate_sampled_cuquantum(self, programs, symbol_names,
+                                        symbol_values, pauli_sums, num_samples,
+                                        forward_pass_vals, grad):
+        """Differentiate a circuit with sampled expectation with GPU ops."""
+        # `self.expectation_op` is already set to cuquantum op at
+        # generate_differentiable_op._differentiate_sam.
+        return self.differentiate_sampled(programs, symbol_names, symbol_values,
+                                          pauli_sums, num_samples,
+                                          forward_pass_vals, grad)
 
     @catch_empty_inputs
     @tf.function

--- a/tensorflow_quantum/python/differentiators/differentiator.py
+++ b/tensorflow_quantum/python/differentiators/differentiator.py
@@ -340,11 +340,13 @@ class Differentiator(metaclass=abc.ABCMeta):
 
     @catch_empty_inputs
     @tf.function
-    def differentiate_analytic_cuquantum(self, programs, symbol_names, symbol_values,
-                               pauli_sums, forward_pass_vals, grad):
+    def differentiate_analytic_cuquantum(self, programs, symbol_names,
+                                         symbol_values, pauli_sums,
+                                         forward_pass_vals, grad):
         # `self.expectation_op` is already set to cuquantum op.
-        return self.differentiate_analytic(programs, symbol_names, symbol_values,
-                               pauli_sums, forward_pass_vals, grad)
+        return self.differentiate_analytic(programs, symbol_names,
+                                           symbol_values, pauli_sums,
+                                           forward_pass_vals, grad)
 
     @catch_empty_inputs
     @tf.function

--- a/tensorflow_quantum/python/differentiators/differentiator_test.py
+++ b/tensorflow_quantum/python/differentiators/differentiator_test.py
@@ -72,6 +72,26 @@ class DifferentiatorTest(tf.test.TestCase):
             WorkingDifferentiator().generate_differentiable_op(
                 sampled_op=lambda programs, symbol_names, pauli_sums: 1)
 
+    def test_generate_differentiable_op_cuquantum(self):
+        """test the type checking on this method with `use_cuquantum`."""
+        WorkingDifferentiator().generate_differentiable_op(
+            analytic_op=lambda programs, symbol_names, symbol_values,
+            pauli_sums: 1,
+            use_cuquantum=True)
+        WorkingDifferentiator().generate_differentiable_op(
+            sampled_op=lambda programs, symbol_names, symbol_values, pauli_sums,
+            num_samples: 1,
+            use_cuquantum=True)
+        with self.assertRaisesRegex(TypeError, expected_regex='boolean'):
+            WorkingDifferentiator().generate_differentiable_op(
+                analytic_op=lambda programs, symbol_names, symbol_values,
+                pauli_sums: 1,
+                use_cuquantum='junk')
+        with self.assertRaisesRegex(TypeError, expected_regex='boolean'):
+            WorkingDifferentiator().generate_differentiable_op(
+                sampled_op=lambda programs, symbol_names, pauli_sums: 1,
+                use_cuquantum='junk')
+
     def test_single_op_link(self):
         """Tests if the `one-differentiator-per-op` policy is working well."""
         wd = WorkingDifferentiator()

--- a/tensorflow_quantum/python/differentiators/differentiator_test.py
+++ b/tensorflow_quantum/python/differentiators/differentiator_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for the differentiator abstract class."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/differentiators/gradient_test.py
+++ b/tensorflow_quantum/python/differentiators/gradient_test.py
@@ -36,6 +36,8 @@ from tensorflow_quantum.core.ops import circuit_execution_ops, batch_util
 from tensorflow_quantum.core.ops.noise import noisy_expectation_op
 from tensorflow_quantum.core.ops.noise import noisy_sampled_expectation_op
 
+RANDOM_SEED = 1234
+
 ANALYTIC_DIFFS = [
     linear_combination.ForwardDifference(grid_spacing=0.0001),
     linear_combination.ForwardDifference(error_order=2, grid_spacing=0.0001),
@@ -57,10 +59,20 @@ ANALYTIC_OPS = [
     circuit_execution_ops.get_expectation_op()  # C++
 ]
 
+ANALYTIC_GPU_OPS = [
+    circuit_execution_ops.get_expectation_op(use_cuquantum=True,
+                                             quantum_concurrent=False)
+]
+
 SAMPLED_OPS = [
     circuit_execution_ops.get_sampled_expectation_op(
         cirq.sim.Simulator()),  # WF
     circuit_execution_ops.get_sampled_expectation_op()  # C++
+]
+
+SAMPLED_GPU_OPS = [
+    circuit_execution_ops.get_sampled_expectation_op(use_cuquantum=True,
+                                                     quantum_concurrent=False)
 ]
 
 NOISY_OPS = [
@@ -117,19 +129,35 @@ class AnalyticGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         list(
-            util.kwargs_cartesian_product(**{
-                'differentiator': ANALYTIC_DIFFS,
-                'op': ANALYTIC_OPS
-            })) + [{
-                'differentiator': adjoint.Adjoint(),
-                'op': circuit_execution_ops.get_expectation_op()
-            }])
-    def test_backprop(self, differentiator, op):
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': ANALYTIC_DIFFS,
+                    'op': ANALYTIC_OPS,
+                    'use_cuquantum': [False],
+                })) + [{
+                    'differentiator': adjoint.Adjoint(),
+                    'op': circuit_execution_ops.get_expectation_op(),
+                    'use_cuquantum': False,
+                }] +
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': ANALYTIC_DIFFS + [adjoint.Adjoint()],
+                    'op': ANALYTIC_GPU_OPS,
+                    'use_cuquantum': [True],
+                })))
+    def test_backprop(self, differentiator, op, use_cuquantum):
         """Test that gradients are correctly backpropagated through a quantum
         circuit via comparison to analytical results.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest()
         differentiator.refresh()
-        op = differentiator.generate_differentiable_op(analytic_op=op)
+        op = differentiator.generate_differentiable_op(
+            analytic_op=op,
+            use_cuquantum=use_cuquantum,
+        )
 
         def exact_grad(theta):
             new_theta = 2 * np.pi * theta
@@ -164,23 +192,42 @@ class AnalyticGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
                     'n_qubits': [5],
                     'n_programs': [3],
                     'n_ops': [3],
-                    'symbol_names': [['a', 'b']]
+                    'symbol_names': [['a', 'b']],
+                    'use_cuquantum': [False],
                 })) + [{
                     'differentiator': adjoint.Adjoint(),
                     'op': circuit_execution_ops.get_expectation_op(),
                     'n_qubits': 10,
                     'n_programs': 5,
                     'n_ops': 3,
-                    'symbol_names': ['a', 'b']
-                }])
+                    'symbol_names': ['a', 'b'],
+                    'use_cuquantum': False,
+                }] +
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': ANALYTIC_DIFFS + [adjoint.Adjoint()],
+                    'op': ANALYTIC_GPU_OPS,
+                    'n_qubits': [5],
+                    'n_programs': [3],
+                    'n_ops': [3],
+                    'symbol_names': [['a', 'b']],
+                    'use_cuquantum': [True],
+                })))
     def test_gradients_vs_cirq_finite_difference(self, differentiator, op,
                                                  n_qubits, n_programs, n_ops,
-                                                 symbol_names):
+                                                 symbol_names, use_cuquantum):
         """Compare TFQ differentiators to fine-grained noiseless cirq finite
         differencing.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest()
         differentiator.refresh()
-        op = differentiator.generate_differentiable_op(analytic_op=op)
+        op = differentiator.generate_differentiable_op(
+            analytic_op=op,
+            use_cuquantum=use_cuquantum,
+        )
 
         qubits = cirq.GridQubit.rect(1, n_qubits)
         circuit_batch, resolver_batch = \
@@ -219,18 +266,39 @@ class AnalyticGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         list(
-            util.kwargs_cartesian_product(**{
-                'differentiator': ANALYTIC_DIFFS,
-                'op': ANALYTIC_OPS,
-            })) + [{
-                'differentiator': adjoint.Adjoint(),
-                'op': circuit_execution_ops.get_expectation_op(),
-            }])
-    def test_analytic_value_with_simple_circuit(self, differentiator, op):
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': ANALYTIC_DIFFS,
+                    'op': ANALYTIC_OPS,
+                    'use_cuquantum': [False],
+                })) + [{
+                    'differentiator': adjoint.Adjoint(),
+                    'op': circuit_execution_ops.get_expectation_op(),
+                    'use_cuquantum': False,
+                }] +
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': ANALYTIC_DIFFS + [adjoint.Adjoint()],
+                    'op': ANALYTIC_GPU_OPS,
+                    'use_cuquantum': [True],
+                })))
+    def test_analytic_value_with_simple_circuit(
+            self,
+            differentiator,
+            op,
+            use_cuquantum,
+    ):
         """Test the value of differentiator with simple circuit."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest()
         # Get an expectation op, with this differentiator attached.
         differentiator.refresh()
-        op = differentiator.generate_differentiable_op(analytic_op=op)
+        op = differentiator.generate_differentiable_op(
+            analytic_op=op,
+            use_cuquantum=use_cuquantum,
+        )
         qubit = cirq.GridQubit(0, 0)
         circuit = util.convert_to_tensor(
             [cirq.Circuit(cirq.X(qubit)**sympy.Symbol('alpha'))])
@@ -248,15 +316,28 @@ class AnalyticGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         list(
-            util.kwargs_cartesian_product(**{
-                'differentiator': ANALYTIC_DIFFS,
-                'op': ANALYTIC_OPS,
-            })) + [{
-                'differentiator': adjoint.Adjoint(),
-                'op': circuit_execution_ops.get_expectation_op(),
-            }])
-    def test_empty_circuit_grad(self, differentiator, op):
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': ANALYTIC_DIFFS,
+                    'op': ANALYTIC_OPS,
+                    'use_cuquantum': [False],
+                })) + [{
+                    'differentiator': adjoint.Adjoint(),
+                    'op': circuit_execution_ops.get_expectation_op(),
+                    'use_cuquantum': False,
+                }] +
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': ANALYTIC_DIFFS + [adjoint.Adjoint()],
+                    'op': ANALYTIC_GPU_OPS,
+                    'use_cuquantum': [True],
+                })))
+    def test_empty_circuit_grad(self, differentiator, op, use_cuquantum):
         """Test that providing no circuits will fail gracefully."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest()
         differentiator.refresh()
         op = differentiator.generate_differentiable_op(analytic_op=op)
         circuit = tf.convert_to_tensor([], dtype=tf.string)
@@ -283,11 +364,20 @@ class SampledGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
                 **{
                     'differentiator': SAMPLED_DIFFS,
                     'op': SAMPLED_OPS,
-                    'num_samples': [20000]
-                })))
+                    'num_samples': [20000],
+                    'use_cuquantum': [False],
+                })) + list(
+                    util.kwargs_cartesian_product(
+                        **{
+                            'differentiator': SAMPLED_DIFFS,
+                            'op': SAMPLED_GPU_OPS,
+                            'num_samples': [20000],
+                            'use_cuquantum': [True],
+                        })))
     def test_sampled_value_with_simple_circuit(self, differentiator, op,
-                                               num_samples):
+                                               num_samples, use_cuquantum):
         """Test the value of sampled differentiator with simple circuit."""
+        tf.random.set_seed(RANDOM_SEED)
         # Get an expectation op, with this differentiator attached.
         differentiator.refresh()
         op = differentiator.generate_differentiable_op(sampled_op=op)
@@ -317,15 +407,30 @@ class SampledGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
                     'n_programs': [5],
                     'n_ops': [2],
                     'symbol_names': [['a', 'b']],
-                    'num_samples': [30000]
+                    'num_samples': [30000],
+                    'use_cuquantum': [False],
+                })) +
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'diff_and_tol': zip(SAMPLED_DIFFS, SAMPLED_DIFFS_TOLS),
+                    'op': SAMPLED_GPU_OPS,
+                    'n_qubits': [3],
+                    'n_programs': [5],
+                    'n_ops': [2],
+                    'symbol_names': [['a', 'b']],
+                    'num_samples': [30000],
+                    'use_cuquantum': [True],
                 })))
     def test_approx_equality_shallow(self, diff_and_tol, op, n_qubits,
                                      symbol_names, n_ops, n_programs,
-                                     num_samples):
+                                     num_samples, use_cuquantum):
         """Test small circuits with limited depth."""
+        tf.random.set_seed(RANDOM_SEED)
         differentiator, tol = diff_and_tol
         differentiator.refresh()
-        op = differentiator.generate_differentiable_op(sampled_op=op)
+        op = differentiator.generate_differentiable_op(
+            sampled_op=op, use_cuquantum=use_cuquantum)
 
         qubits = cirq.GridQubit.rect(1, n_qubits)
         circuit_batch, resolver_batch = \
@@ -368,12 +473,22 @@ class SampledGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         list(
-            util.kwargs_cartesian_product(**{
-                'differentiator': SAMPLED_DIFFS,
-                'op': SAMPLED_OPS,
-            })))
-    def test_empty_circuit_sampled_grad(self, differentiator, op):
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': SAMPLED_DIFFS,
+                    'op': SAMPLED_OPS,
+                    'use_cuquantum': [False],
+                })) + list(
+                    util.kwargs_cartesian_product(
+                        **{
+                            'differentiator': SAMPLED_DIFFS,
+                            'op': SAMPLED_GPU_OPS,
+                            'use_cuquantum': [True],
+                        })))
+    def test_empty_circuit_sampled_grad(self, differentiator, op,
+                                        use_cuquantum):
         """Test that providing no circuits will fail gracefully."""
+        tf.random.set_seed(RANDOM_SEED)
         differentiator.refresh()
         op = differentiator.generate_differentiable_op(sampled_op=op)
         circuit = tf.convert_to_tensor([], dtype=tf.string)

--- a/tensorflow_quantum/python/differentiators/gradient_test.py
+++ b/tensorflow_quantum/python/differentiators/gradient_test.py
@@ -152,7 +152,7 @@ class AnalyticGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         """
         if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
             # GPU is not set. Ignores this sub-test.
-            self.skipTest()
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         differentiator.refresh()
         op = differentiator.generate_differentiable_op(
             analytic_op=op,
@@ -222,7 +222,7 @@ class AnalyticGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         """
         if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
             # GPU is not set. Ignores this sub-test.
-            self.skipTest()
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         differentiator.refresh()
         op = differentiator.generate_differentiable_op(
             analytic_op=op,
@@ -292,7 +292,7 @@ class AnalyticGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         """Test the value of differentiator with simple circuit."""
         if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
             # GPU is not set. Ignores this sub-test.
-            self.skipTest()
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         # Get an expectation op, with this differentiator attached.
         differentiator.refresh()
         op = differentiator.generate_differentiable_op(
@@ -337,7 +337,7 @@ class AnalyticGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         """Test that providing no circuits will fail gracefully."""
         if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
             # GPU is not set. Ignores this sub-test.
-            self.skipTest()
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         differentiator.refresh()
         op = differentiator.generate_differentiable_op(analytic_op=op)
         circuit = tf.convert_to_tensor([], dtype=tf.string)
@@ -377,6 +377,9 @@ class SampledGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
     def test_sampled_value_with_simple_circuit(self, differentiator, op,
                                                num_samples, use_cuquantum):
         """Test the value of sampled differentiator with simple circuit."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         # Get an expectation op, with this differentiator attached.
         differentiator.refresh()
@@ -426,6 +429,9 @@ class SampledGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
                                      symbol_names, n_ops, n_programs,
                                      num_samples, use_cuquantum):
         """Test small circuits with limited depth."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         differentiator, tol = diff_and_tol
         differentiator.refresh()
@@ -488,6 +494,9 @@ class SampledGradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
     def test_empty_circuit_sampled_grad(self, differentiator, op,
                                         use_cuquantum):
         """Test that providing no circuits will fail gracefully."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         differentiator.refresh()
         op = differentiator.generate_differentiable_op(sampled_op=op)

--- a/tensorflow_quantum/python/differentiators/gradient_test.py
+++ b/tensorflow_quantum/python/differentiators/gradient_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Testing for gradient calculation consistency in TFQ."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/differentiators/linear_combination.py
+++ b/tensorflow_quantum/python/differentiators/linear_combination.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Compute gradients by combining function values linearly."""
 import numbers
 

--- a/tensorflow_quantum/python/differentiators/linear_combination_test.py
+++ b/tensorflow_quantum/python/differentiators/linear_combination_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Basic tests for the LinearCombinationDifferentiator"""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/differentiators/parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/parameter_shift.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Compute analytic gradients by using general parameter-shift rule. """
 import tensorflow as tf
 

--- a/tensorflow_quantum/python/differentiators/parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/parameter_shift_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Basic tests for the ParameterShift differentiator"""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/differentiators/parameter_shift_util.py
+++ b/tensorflow_quantum/python/differentiators/parameter_shift_util.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Util functions for general parameter-shift rule. """
 import numpy as np
 import tensorflow as tf

--- a/tensorflow_quantum/python/differentiators/parameter_shift_util_test.py
+++ b/tensorflow_quantum/python/differentiators/parameter_shift_util_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Basic tests for utility functions for ParameterShift"""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/__init__.py
+++ b/tensorflow_quantum/python/layers/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module definitions for tensorflow_quantum.python.layers.*"""
 # Utility layers.
 from tensorflow_quantum.python.layers.circuit_construction import (

--- a/tensorflow_quantum/python/layers/circuit_construction/__init__.py
+++ b/tensorflow_quantum/python/layers/circuit_construction/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.python.layers.circuit_construction.*"""
 
 # pylint: disable=line-too-long

--- a/tensorflow_quantum/python/layers/circuit_construction/elementary.py
+++ b/tensorflow_quantum/python/layers/circuit_construction/elementary.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Elementary layers, such as the AddCircuit layer."""
 import numpy as np
 import tensorflow as tf

--- a/tensorflow_quantum/python/layers/circuit_construction/elementary_test.py
+++ b/tensorflow_quantum/python/layers/circuit_construction/elementary_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for the elementary layers."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/circuit_executors/__init__.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.python.layers.circuit_executors.*"""
 
 # pylint: disable=line-too-long

--- a/tensorflow_quantum/python/layers/circuit_executors/expectation.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/expectation.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A tf.keras.layer that ingests programs and outputs expectation values."""
 import numbers
 
@@ -285,15 +285,20 @@ class Expectation(tf.keras.layers.Layer):
              symbol_values=None,
              operators=None,
              repetitions=None,
-             initializer=tf.keras.initializers.RandomUniform(0, 2 * np.pi)):
+             initializer=None):
         """Keras call function.
 
-        Input options:
-            `inputs`, `symbol_names`, `symbol_values`:
-                see `input_checks.expand_circuits`
-            `operators`: see `input_checks.expand_operators`
+        Args:
+            inputs: See `input_checks.expand_circuits.
+            symbol_names: See `input_checks.expand_circuits.
+            symbol_values: See `input_checks.expand_circuits.
+            operators: See `input_checks.expand_operators`
+            repetitions: A Python `int` or a pre-converted `tf.Tensor`
+                containing a single `int` entry.
+            initializer: The keras initializer object for weights.
+                Defaults to uniform distribution [0..2*pi]
 
-        Output shape:
+        Returns:
             `tf.Tensor` with shape [batch_size, n_ops] that holds the
                 expectation value for each circuit with each op applied to it
                 (after resolving the corresponding parameters in).
@@ -301,6 +306,9 @@ class Expectation(tf.keras.layers.Layer):
         values_empty = False
         if symbol_values is None:
             values_empty = True
+
+        if initializer is None:
+            initializer = tf.keras.initializers.RandomUniform(0, 2 * np.pi)
 
         inputs, symbol_names, symbol_values = input_checks.expand_circuits(
             inputs, symbol_names, symbol_values)

--- a/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
@@ -31,6 +31,8 @@ from tensorflow_quantum.python.layers.circuit_executors import expectation
 from tensorflow_quantum.python.differentiators import linear_combination
 from tensorflow_quantum.python import util
 
+RANDOM_SEED = 1234
+
 
 def _gen_single_bit_rotation_problem(bit, symbols, noisy):
     """Generate a toy problem on 1 qubit."""

--- a/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for tensorflow_quantum.layers.circuit_executors.expectation."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position
@@ -48,7 +48,7 @@ def _gen_single_bit_rotation_problem(bit, symbols, noisy):
     return circuit
 
 
-class ExpectationTest(tf.test.TestCase):
+class ExpectationTest(parameterized.TestCase, tf.test.TestCase):
     """Basic tests for the expectation layer."""
 
     def test_expectation_instantiate(self):
@@ -283,10 +283,17 @@ class ExpectationTest(tf.test.TestCase):
             ], [cirq.Z(bit), cirq.Z(bit), cirq.Z(bit)]],
             repetitions=[[1, 2, 3], [4, 5, 6]])
 
-    def test_expectation_simple_tf_train(self):
+    @parameterized.parameters([{
+        'use_cuquantum': False,
+    }, {
+        'use_cuquantum': True,
+    }])
+    def test_expectation_simple_tf_train(self, use_cuquantum):
         """Train a layer using standard tf (not keras).
         This is a subtle test that will work since we don't use keras compile.
         """
+        tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2 * np.pi)
         bit = cirq.GridQubit(0, 0)
         circuit = \
             cirq.Circuit(cirq.rx(sympy.Symbol('theta'))(bit))
@@ -297,7 +304,8 @@ class ExpectationTest(tf.test.TestCase):
             with tf.GradientTape() as tape:
                 circuit_out = layer(circuit,
                                     symbol_names=['theta'],
-                                    operators=op)
+                                    operators=op,
+                                    initializer=initializer)
                 mse = tf.square(tf.reduce_sum(tf.subtract(circuit_out, -1)))
             grads = tape.gradient(mse, layer.trainable_weights)
             optimizer.apply_gradients(zip(grads, layer.trainable_weights))
@@ -331,6 +339,8 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
+        tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2 * np.pi)
         noisy = backend == 'noisy'
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
@@ -348,7 +358,8 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
           symbol_names=symbols,
           operators=cirq.Z(bit),
           symbol_values=l2,
-          repetitions=reps)
+          repetitions=reps,
+          initializer=initializer)
         model = tf.keras.Model(inputs=[datum, inputs], outputs=outputs)
 
         data_in = np.array([[1], [0]], dtype=np.float32)
@@ -386,6 +397,8 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
+        tf.random.set_seed(RANDOM_SEED)
+        normal_initializer = tf.keras.initializers.RandomNormal()
         noisy = backend == 'noisy'
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')
@@ -406,7 +419,7 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         )(circuit_input,
           symbol_names=symbols,
           operators=op_input,
-          initializer=tf.keras.initializers.RandomNormal(),
+          initializer=normal_initializer,
           repetitions=reps)
 
         model = tf.keras.Model(
@@ -453,6 +466,8 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
+        tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2 * np.pi)
         noisy = backend == 'noisy'
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')
@@ -475,7 +490,8 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
           symbol_names=symbols,
           symbol_values=dense_2,
           operators=op_inp,
-          repetitions=reps)
+          repetitions=reps,
+          initializer=initializer)
 
         functional_model = tf.keras.Model(
             inputs=[data_inp, op_inp, circuit_inp], outputs=[circuit_output])
@@ -513,6 +529,9 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
+        tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2 * np.pi)
+
         noisy = backend == 'noisy'
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')
@@ -533,7 +552,8 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
           symbol_names=symbols,
           symbol_values=d2,
           operators=cirq.Z(bit),
-          repetitions=reps)
+          repetitions=reps,
+          initializer=initializer)
         d3 = tf.keras.layers.Dense(1)(quantum)
 
         model = tf.keras.Model(inputs=[circuit_input, classical_input],

--- a/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
@@ -26,6 +26,7 @@ import sympy
 import tensorflow as tf
 
 import cirq
+from tensorflow_quantum.core.ops import circuit_execution_ops
 from tensorflow_quantum.python.layers.circuit_executors import expectation
 from tensorflow_quantum.python.differentiators import linear_combination
 from tensorflow_quantum.python import util
@@ -327,6 +328,9 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         state given the input zero or one. This tests the input signature:
         Expectation([input_value_batch]).
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         noisy = backend == 'noisy'
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
@@ -379,6 +383,9 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         Learn qubit in the z+ state using two different measurement operators.
         This tests input signature Expectation([operator_batch])
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         noisy = backend == 'noisy'
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')
@@ -443,6 +450,9 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         binary input. This tests the input signature:
         Expectation([value_batch, operator_batch]).
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         noisy = backend == 'noisy'
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')
@@ -500,6 +510,9 @@ class ExpectationFunctionalTests(parameterized.TestCase, tf.test.TestCase):
         Train the network to output +-5 given an input of 1 or 0. This tests
         that everything works when Expectation layer is a middle layers.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         noisy = backend == 'noisy'
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')

--- a/tensorflow_quantum/python/layers/circuit_executors/input_checks.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/input_checks.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Input checks common to circuit execution layers."""
 import numpy as np
 import sympy

--- a/tensorflow_quantum/python/layers/circuit_executors/input_checks_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/input_checks_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for tensorflow_quantum.layers.circuit_executors.input_checks."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/circuit_executors/sample.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A tf.keras.layer that ingests programs and outputs bitstring samples."""
 import numbers
 
@@ -179,17 +179,18 @@ class Sample(tf.keras.layers.Layer):
              repetitions=None):
         """Keras call function.
 
-        Input options:
-            `inputs`, `symbol_names`, `symbol_values`:
-                see `input_checks.expand_circuits`
-            `repetitions`: a Python `int` or a pre-converted
-                `tf.Tensor` containing a single `int` entry.
+        Args:
+            inputs: See `input_checks.expand_circuits`.
+            symbol_names: See `input_checks.expand_circuits`.
+            symbol_values: See `input_checks.expand_circuits`.
+            repetitions: A Python `int` or a pre-converted `tf.Tensor`
+                containing a single `int` entry.
 
-        Output shape:
+        Returns:
             `tf.RaggedTensor` with shape:
-                [batch size of symbol_values, repetitions, <ragged string size>]
-                    or
-                [number of circuits, repetitions, <ragged string size>]
+            [batch size of symbol_values, repetitions, <ragged string size>]
+                or
+            [number of circuits, repetitions, <ragged string size>]
         """
         if repetitions is None:
             raise ValueError("Number of repetitions not specified.")

--- a/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
@@ -29,6 +29,8 @@ import cirq
 from tensorflow_quantum.python.layers.circuit_executors import sample
 from tensorflow_quantum.python import util
 
+RANDOM_SEED = 1234
+
 
 class SampleTest(tf.test.TestCase, parameterized.TestCase):
     """Tests for the Sample layer."""
@@ -188,6 +190,7 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
         cause what is output from the layer to structurally deviate from what
         is expected.
         """
+        tf.random.set_seed(RANDOM_SEED)
         if use_cuquantum:
             # If use_cuquantum is True,
             if backend is not None and backend != 'noiseless':

--- a/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for the sample layer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
@@ -26,6 +26,7 @@ import sympy
 import tensorflow as tf
 import cirq
 
+from tensorflow_quantum.core.ops import circuit_execution_ops
 from tensorflow_quantum.python.layers.circuit_executors import sample
 from tensorflow_quantum.python import util
 
@@ -109,6 +110,9 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
     ])
     def test_sample_invalid_combinations(self, backend, use_cuquantum):
         """Test with valid type inputs and valid value, but incorrect combo."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         sampler = sample.Sample(backend, use_cuquantum=use_cuquantum)
         symbol = sympy.Symbol('alpha')
         circuit = cirq.Circuit(cirq.H(cirq.GridQubit(0, 0))**symbol)
@@ -151,9 +155,17 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
                     symbol_values=np.zeros((3, 1)),
                     repetitions=5)
 
-    def test_sample_basic_inputs(self):
+    @parameterized.parameters([{
+        'use_cuquantum': False,
+    }, {
+        'use_cuquantum': True,
+    }])
+    def test_sample_basic_inputs(self, use_cuquantum):
         """Test that sample ingests inputs correctly in simple settings."""
-        sampler = sample.Sample()
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
+        sampler = sample.Sample(use_cuquantum=use_cuquantum)
         sampler(cirq.Circuit(), repetitions=10)
         sampler([cirq.Circuit()], repetitions=10)
         sampler(cirq.Circuit(),
@@ -165,9 +177,17 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
                 symbol_values=[[0.5]],
                 repetitions=10)
 
-    def test_sample_outputs_simple(self):
+    @parameterized.parameters([{
+        'use_cuquantum': False,
+    }, {
+        'use_cuquantum': True,
+    }])
+    def test_sample_outputs_simple(self, use_cuquantum):
         """Test the simplest call where nothing but circuits are provided."""
-        sampler = sample.Sample()
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
+        sampler = sample.Sample(use_cuquantum=use_cuquantum)
         circuit = cirq.Circuit(cirq.H(cirq.GridQubit(0, 0)))
         output = sampler([circuit, circuit], repetitions=5)
         self.assertShapeEqual(np.empty((2, 5, 1)), output.to_tensor())
@@ -190,6 +210,9 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
         cause what is output from the layer to structurally deviate from what
         is expected.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         if use_cuquantum:
             # If use_cuquantum is True,

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A tf.keras.layer that ingests programs and outputs sampled expectation values
 ."""
 import numbers
@@ -280,24 +280,30 @@ class SampledExpectation(tf.keras.layers.Layer):
              symbol_values=None,
              operators=None,
              repetitions=None,
-             initializer=tf.keras.initializers.RandomUniform(0, 2 * np.pi)):
+             initializer=None):
         """Keras call function.
 
-        Input options:
-            `inputs`, `symbol_names`, `symbol_values`:
-                see `input_checks.expand_circuits`
-            `operators`: see `input_checks.expand_operators`
-            `repetitions`: a Python `int` or a pre-converted
-                `tf.Tensor` containing a single `int` entry.
+        Args:
+            inputs: See `input_checks.expand_circuits.
+            symbol_names: See `input_checks.expand_circuits.
+            symbol_values: See `input_checks.expand_circuits.
+            operators: See `input_checks.expand_operators`
+            repetitions: A Python `int` or a pre-converted `tf.Tensor`
+                containing a single `int` entry.
+            initializer: The keras initializer object for weights.
+                Defaults to uniform distribution [0..2*pi]
 
-        Output shape:
+        Returns:
             `tf.Tensor` with shape [batch_size, n_ops] that holds the
-                expectation value for each circuit with each op applied to it
-                (after resolving the corresponding parameters in).
+            expectation value for each circuit with each op applied to it
+            (after resolving the corresponding parameters in).
         """
         values_empty = False
         if symbol_values is None:
             values_empty = True
+
+        if initializer is None:
+            initializer = tf.keras.initializers.RandomUniform(0, 2 * np.pi)
 
         inputs, symbol_names, symbol_values = input_checks.expand_circuits(
             inputs, symbol_names, symbol_values)

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for tensorflow_quantum.layers.circuit_executors.sampled_expectation."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position
@@ -403,6 +403,7 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2*np.pi)
         bit = cirq.GridQubit(0, 0)
         circuit = cirq.Circuit(cirq.rx(sympy.Symbol('theta'))(bit))
         layer = sampled_expectation.SampledExpectation(
@@ -413,7 +414,8 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
                 circuit_out = layer(circuit,
                                     symbol_names=['theta'],
                                     operators=cirq.Z(bit),
-                                    repetitions=100)
+                                    repetitions=100
+                                    initializer=initializer)
                 mse = tf.square(tf.reduce_sum(tf.subtract(circuit_out, -1)))
             grads = tape.gradient(mse, layer.trainable_weights)
             optimizer.apply_gradients(zip(grads, layer.trainable_weights))
@@ -444,6 +446,7 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2*np.pi)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
         circuit = _gen_single_bit_rotation_problem(
@@ -460,7 +463,8 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
           symbol_names=symbols,
           operators=cirq.Z(bit),
           symbol_values=l2,
-          repetitions=5000)
+          repetitions=5000,
+          initializer=initializer)
         model = tf.keras.Model(inputs=[datum, inputs], outputs=outputs)
 
         data_in = np.array([[1], [0]], dtype=np.float32)
@@ -493,6 +497,7 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2*np.pi)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
         ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.Z(bit)]])
@@ -513,7 +518,8 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         )(circuit_inp,
           symbol_names=symbols,
           operators=op_inp,
-          repetitions=n_inp)
+          repetitions=n_inp,
+          initializer=initializer)
         model = tf.keras.Model(inputs=[circuit_inp, op_inp, n_inp],
                                outputs=[circuit_output])
 
@@ -548,6 +554,7 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2*np.pi)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
         ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.Z(bit)]])
@@ -572,7 +579,8 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
           symbol_names=symbols,
           symbol_values=dense_2,
           operators=op_inp,
-          repetitions=n_inp)
+          repetitions=n_inp,
+          initializer=initializer)
 
         functional_model = tf.keras.Model(
             inputs=[circuit_inp, data_inp, op_inp, n_inp],
@@ -607,6 +615,7 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
             # GPU is not set. Ignores this sub-test.
             self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
+        initializer = tf.keras.initializers.RandomUniform(0, 2*np.pi)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')
         circuits = util.convert_to_tensor([
@@ -627,7 +636,8 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
           symbol_names=symbols,
           symbol_values=d2,
           operators=cirq.Z(bit),
-          repetitions=5000)
+          repetitions=5000,
+          initializer=initializer)
         d3 = tf.keras.layers.Dense(1)(quantum)
 
         model = tf.keras.Model(inputs=[circuit_input, classical_input],

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
@@ -26,6 +26,7 @@ import sympy
 import tensorflow as tf
 
 import cirq
+from tensorflow_quantum.core.ops import circuit_execution_ops
 from tensorflow_quantum.python.layers.circuit_executors import \
     sampled_expectation
 from tensorflow_quantum.python.differentiators import linear_combination
@@ -130,6 +131,9 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
     def test_sampled_expectation_type_inputs_error(self, backend,
                                                    use_cuquantum):
         """Test that SampledExpectation errors within Keras call."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
 
         bit = cirq.GridQubit(0, 0)
         symbol = sympy.Symbol('alpha')
@@ -197,6 +201,10 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
     ])
     def test_sampled_expectation_op_error(self, backend, use_cuquantum):
         """Test that expectation errors within underlying ops correctly."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
+
         # Note the expected_regex is left blank here since there is a
         # discrepancy between the error strings provided between backends.
         bit = cirq.GridQubit(0, 0)
@@ -300,6 +308,9 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
     ])
     def test_static_cases(self, backend, use_cuquantum):
         """Run inputs through in complex cases."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
 
         bit = cirq.GridQubit(0, 0)
         symbol = sympy.Symbol('alpha')
@@ -381,12 +392,21 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
                      cirq.X(bit) + 2.0 * cirq.Z(bit)],
           repetitions=[5, 1])
 
-    def test_sampled_expectation_simple_tf_train(self):
+    @parameterized.parameters([{
+        'use_cuquantum': False,
+    }, {
+        'use_cuquantum': True,
+    }])
+    def test_sampled_expectation_simple_tf_train(self, use_cuquantum):
         """Train a layer using standard tf (not keras)."""
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         circuit = cirq.Circuit(cirq.rx(sympy.Symbol('theta'))(bit))
-        layer = sampled_expectation.SampledExpectation()
+        layer = sampled_expectation.SampledExpectation(
+            use_cuquantum=use_cuquantum)
         optimizer = tf.optimizers.Adam(learning_rate=0.05)
         for _ in range(10):
             with tf.GradientTape() as tape:
@@ -420,6 +440,9 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         This model will put a qubit in the zero or one state from a random state
         given the input zero or one.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
@@ -466,6 +489,9 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
 
         Learn qubit in the z+ state using two different measurement operators.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
@@ -518,6 +544,9 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         Train a NN to put a qubit in the z+ or x+ states based on a classical
         binary input.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
@@ -574,6 +603,9 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         Train the network to output +-5 given an input of 1 or 0. This tests
         that everything works when SampledExpectation layer is a middle layers.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
@@ -31,6 +31,8 @@ from tensorflow_quantum.python.layers.circuit_executors import \
 from tensorflow_quantum.python.differentiators import linear_combination
 from tensorflow_quantum.python import util
 
+RANDOM_SEED = 1234
+
 
 class CustomSampler(cirq.Sampler):
     """Wrapper for cirq.Simulator to confirm that custom samplers work."""
@@ -381,6 +383,7 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
 
     def test_sampled_expectation_simple_tf_train(self):
         """Train a layer using standard tf (not keras)."""
+        tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         circuit = cirq.Circuit(cirq.rx(sympy.Symbol('theta'))(bit))
         layer = sampled_expectation.SampledExpectation()
@@ -417,6 +420,7 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         This model will put a qubit in the zero or one state from a random state
         given the input zero or one.
         """
+        tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
         circuit = _gen_single_bit_rotation_problem(
@@ -462,6 +466,7 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
 
         Learn qubit in the z+ state using two different measurement operators.
         """
+        tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
         ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.Z(bit)]])
@@ -513,6 +518,7 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         Train a NN to put a qubit in the z+ or x+ states based on a classical
         binary input.
         """
+        tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
         ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.Z(bit)]])
@@ -568,6 +574,7 @@ class SampledExpectationFunctionalTests(parameterized.TestCase,
         Train the network to output +-5 given an input of 1 or 0. This tests
         that everything works when SampledExpectation layer is a middle layers.
         """
+        tf.random.set_seed(RANDOM_SEED)
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')
         circuits = util.convert_to_tensor([

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
@@ -409,12 +409,12 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
         layer = sampled_expectation.SampledExpectation(
             use_cuquantum=use_cuquantum)
         optimizer = tf.optimizers.Adam(learning_rate=0.05)
-        for _ in range(10):
+        for _ in range(20):
             with tf.GradientTape() as tape:
                 circuit_out = layer(circuit,
                                     symbol_names=['theta'],
                                     operators=cirq.Z(bit),
-                                    repetitions=100
+                                    repetitions=100,
                                     initializer=initializer)
                 mse = tf.square(tf.reduce_sum(tf.subtract(circuit_out, -1)))
             grads = tape.gradient(mse, layer.trainable_weights)

--- a/tensorflow_quantum/python/layers/circuit_executors/state.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/state.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A tf.keras.layer that ingests programs and parameters and outputs a state."""
 import tensorflow as tf
 
@@ -150,11 +150,12 @@ class State(tf.keras.layers.Layer):
     def call(self, inputs, *, symbol_names=None, symbol_values=None):
         """Keras call function.
 
-        Input options:
-            `inputs`, `symbol_names`, `symbol_values`:
-                see `input_checks.expand_circuits`
+        Args:
+            inputs: See `input_checks.expand_circuits.
+            symbol_names: See `input_checks.expand_circuits.
+            symbol_values: See `input_checks.expand_circuits.
 
-        Output shape:
+        Returns:
             `tf.RaggedTensor` with shape:
                 [batch size of symbol_values, <size of state>]
                     or

--- a/tensorflow_quantum/python/layers/circuit_executors/state_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/state_test.py
@@ -26,6 +26,7 @@ import sympy
 import tensorflow as tf
 import cirq
 
+from tensorflow_quantum.core.ops import circuit_execution_ops
 from tensorflow_quantum.python.layers.circuit_executors import state
 from tensorflow_quantum.python import util
 
@@ -59,7 +60,10 @@ class StateTest(parameterized.TestCase, tf.test.TestCase):
     }])
     def test_state_invalid_combinations(self, backend, use_cuquantum):
         """Test with valid type inputs and valid value, but incorrect combo."""
-        state_calc = state.State(backend, use_cuquantum)
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
+        state_calc = state.State(backend, use_cuquantum=use_cuquantum)
         symbol = sympy.Symbol('alpha')
         circuit = cirq.Circuit(cirq.H(cirq.GridQubit(0, 0))**symbol)
         with self.assertRaisesRegex(Exception, expected_regex=""):
@@ -142,6 +146,9 @@ class StateTest(parameterized.TestCase, tf.test.TestCase):
         post processing done inside the layers should not cause output from the
         layer to structurally deviate from what is expected.
         """
+        if use_cuquantum and not circuit_execution_ops.is_gpu_configured():
+            # GPU is not set. Ignores this sub-test.
+            self.skipTest("GPU is not set. Ignoring gpu tests...")
         backend = backend_output[0]
         output = backend_output[1]
         state_executor = state.State(

--- a/tensorflow_quantum/python/layers/circuit_executors/state_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/state_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for tensorflow_quantum.layers.circuit_executors.state."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/circuit_executors/unitary.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/unitary.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A tf.keras.layer that ingests programs and outputs a unitary."""
 import tensorflow as tf
 

--- a/tensorflow_quantum/python/layers/circuit_executors/unitary_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/unitary_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for tensorflow_quantum.layers.circuit_executors.unitary."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/high_level/__init__.py
+++ b/tensorflow_quantum/python/layers/high_level/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.python.layers.high_level.*"""
 
 # pylint: disable=line-too-long

--- a/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.python.layers.high_level.controlled_pqc layer."""
 import numbers
 import numpy as np

--- a/tensorflow_quantum/python/layers/high_level/controlled_pqc_test.py
+++ b/tensorflow_quantum/python/layers/high_level/controlled_pqc_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test module for tfq.python.layers.high_level.controlled_pqc layer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.python.layers.high_level.noisy_controlled_pqc layer."""
 import numbers
 import numpy as np

--- a/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc_test.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test module for tfq.python.layers.high_level.controlled_pqc layer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/high_level/noisy_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_pqc.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.python.layers.high_level.noisy_pqc layer."""
 import numbers
 import numpy as np

--- a/tensorflow_quantum/python/layers/high_level/noisy_pqc_test.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_pqc_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test module for tfq.python.layers.high_level.noisy_pqc layer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/layers/high_level/pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/pqc.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module for tfq.python.layers.high_level.pqc layer."""
 import numbers
 import numpy as np

--- a/tensorflow_quantum/python/layers/high_level/pqc_test.py
+++ b/tensorflow_quantum/python/layers/high_level/pqc_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test module for tfq.python.layers.high_level.pqc layer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/optimizers/__init__.py
+++ b/tensorflow_quantum/python/optimizers/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Module definitions for tensorflow_quantum.python.optimizers.*"""
 
 # Quantum circuit specific optimizers.

--- a/tensorflow_quantum/python/optimizers/rotosolve_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/rotosolve_minimizer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """The rotosolve minimization algorithm."""
 import numpy as np
 import tensorflow as tf

--- a/tensorflow_quantum/python/optimizers/rotosolve_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/rotosolve_minimizer_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test module for tfq.python.optimizers.rotosolve_minimizer optimizer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """The SPSA minimization algorithm."""
 import tensorflow as tf
 import numpy as np

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Test module for tfq.python.optimizers.spsa_minimizer optimizer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/quantum_context.py
+++ b/tensorflow_quantum/python/quantum_context.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A global singleton object for defining op execution parameters."""
 
 import multiprocessing

--- a/tensorflow_quantum/python/quantum_context_test.py
+++ b/tensorflow_quantum/python/quantum_context_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for quantum_context functions."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """A collection of helper functions which are useful in places in TFQ."""
 
 import itertools

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# =============================================================================
 """Tests for TFQ utilities."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position


### PR DESCRIPTION
From this PR, other differentiators like `ParameterShift()`, `LinearCombination` and its subclasses can be accelerated with cuquantum `expectation` and `sampled_expectation` op.